### PR TITLE
Fix bundle by modifying babel configuration

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,10 +1,10 @@
-module.exports = api => ({
+module.exports = {
 	"presets": [
 		"@babel/preset-env"
 	],
 	"plugins": [
 		"@babel/plugin-proposal-class-properties",
-		...(api.env('test') ? ["@babel/plugin-transform-runtime"] : [])
+		"@babel/plugin-transform-runtime"
 	]
-})
+}
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -24,7 +24,7 @@ export default {
 	plugins: [
 		babel({
 			exclude: 'node_modules/**',
-			babelHelpers: 'bundled'
+			babelHelpers: 'runtime'
 		}),
 		resolve(),
 		commonjs(),


### PR DESCRIPTION
Switch `@rollup/plugin-babel/babelHelpers` option from `bundled` to `runtime` and include `regenerator-runtime` to include `async/await` polyfill but increase the bundle size just as needed.