### PR TITLE
Add exist event

### DIFF
--- a/src/DOMObserver.js
+++ b/src/DOMObserver.js
@@ -1,10 +1,11 @@
 import isElement from './utils/isElement'
 
 class DOMObserver {
+	static EXIST = 'DOMObserver_exist'
 	static ADD = 'DOMObserver_add'
 	static REMOVE = 'DOMObserver_remove'
 	static CHANGE = 'DOMObserver_change'
-	static EVENTS = [DOMObserver.ADD, DOMObserver.REMOVE, DOMObserver.CHANGE]
+	static EVENTS = [DOMObserver.EXIST, DOMObserver.ADD, DOMObserver.REMOVE, DOMObserver.CHANGE]
 
 	_observer = null
 
@@ -17,11 +18,11 @@ class DOMObserver {
 
 		return new Promise((resolve, reject) => {
 			const el = isElement(target) ? target : document.querySelector(target)
-			if (!!el && events.includes(DOMObserver.ADD)) {
+			if (!!el && events.includes(DOMObserver.EXIST)) {
 				if (onEvent) {
-					onEvent(el, DOMObserver.ADD)
+					onEvent(el, DOMObserver.EXIST)
 				} else {
-					resolve({ node: el, event: DOMObserver.ADD })
+					resolve({ node: el, event: DOMObserver.EXIST })
 				}
 			}
 

--- a/src/__tests__/DOMObserver.test.js
+++ b/src/__tests__/DOMObserver.test.js
@@ -31,7 +31,7 @@ describe('DOMObserver', () => {
 
 				it('Observes an element to be added', () => {
 					instance.wait('#foo', onEvent)
-					expect(onEvent).toHaveBeenCalledWith(el, DOMObserver.ADD)
+					expect(onEvent).toHaveBeenCalledWith(el, DOMObserver.EXIST)
 				})
 
 				it('Ignores an element to be added', async () => {
@@ -119,7 +119,7 @@ describe('DOMObserver', () => {
 				it('Observes an element to be added', async () => {
 					const { node, event } = await instance.wait('#foo')
 					expect(node).toEqual(el)
-					expect(event).toBe(DOMObserver.ADD)
+					expect(event).toBe(DOMObserver.EXIST)
 				})
 
 				it('Observes an element to be removed', async () => {
@@ -182,7 +182,7 @@ describe('DOMObserver', () => {
 
 				it('Observes an element to be added', () => {
 					instance.wait(el, onEvent)
-					expect(onEvent).toHaveBeenCalledWith(el, DOMObserver.ADD)
+					expect(onEvent).toHaveBeenCalledWith(el, DOMObserver.EXIST)
 				})
 
 				it('Observes an element to be removed', async () => {


### PR DESCRIPTION
This PR adds the new event `EXIST` triggered when the observed element already exists when the `wait` method is called. Previously the `ADD` was thrown to handle that use case. This allows to disambiguate such situations.
This is a breaking change though.