### PR TITLE
fix: Disconnect observer and clear timeout after wait() resolves

### DIFF
--- a/src/DOMObserver.ts
+++ b/src/DOMObserver.ts
@@ -87,18 +87,15 @@ class DOMObserver {
 				settle(options ? { node, event, options } : { node, event })
 
 			if (signal) {
-				onAbort = () => {
-					this.clear()
-					cancel(signal.reason ?? new DOMException('Aborted', 'AbortError'))
-				}
+				onAbort = () => cancel(signal.reason ?? new DOMException('Aborted', 'AbortError'))
 				signal.addEventListener('abort', onAbort, { once: true })
 			}
 
 			if (timeout > 0) {
-				this._timeout = setTimeout(() => {
-					this.clear()
-					cancel(new Error(`[TIMEOUT]: Element ${target} cannot be found after ${timeout}ms`))
-				}, timeout)
+				this._timeout = setTimeout(
+					() => cancel(new Error(`[TIMEOUT]: Element ${target} cannot be found after ${timeout}ms`)),
+					timeout
+				)
 			}
 
 			this._observe(target, callback, { events, attributeFilter })

--- a/src/DOMObserver.ts
+++ b/src/DOMObserver.ts
@@ -51,12 +51,7 @@ class DOMObserver {
 
 	wait(
 		target: DOMTarget,
-		{
-			events = DOMObserver.EVENTS,
-			timeout = 0,
-			attributeFilter = undefined,
-			signal = undefined,
-		}: WaitOptions = {}
+		{ events = DOMObserver.EVENTS, timeout = 0, attributeFilter = undefined, signal = undefined }: WaitOptions = {}
 	): Promise<WaitResult> {
 		if (!events?.length) {
 			return Promise.reject(new Error('[EVENTS]: events array cannot be empty'))
@@ -107,6 +102,8 @@ class DOMObserver {
 			}
 
 			this._observe(target, callback, { events, attributeFilter })
+		}).finally(() => {
+			this.clear()
 		})
 	}
 

--- a/src/__tests__/DOMObserver.test.ts
+++ b/src/__tests__/DOMObserver.test.ts
@@ -98,9 +98,9 @@ describe('DOMObserver', () => {
 				})
 
 				it('Does not clear a subsequent watch() when timeout was set', async () => {
-					await instance.wait('#foo', { timeout: 200 })
+					await instance.wait('#foo', { timeout: 100 })
 					instance.watch('#foo', vi.fn<OnEventCallback>(), { events: [DOMObserver.CHANGE] })
-					await _sleep(250)
+					await _sleep(150)
 					expect(instance.isObserving).toBe(true)
 				})
 			})

--- a/src/__tests__/DOMObserver.test.ts
+++ b/src/__tests__/DOMObserver.test.ts
@@ -59,12 +59,9 @@ describe('DOMObserver', () => {
 				})
 
 				it('Rejects promise when an element is not found after timeout is elapsed', async () => {
-					const instance = new DOMObserver()
-					try {
-						await instance.wait('#foo', { timeout: 50 })
-					} catch (error) {
-						expect((error as Error).message).toMatch('[TIMEOUT]')
-					}
+					await expect(instance.wait('#bar', { events: [DOMObserver.ADD], timeout: 50 })).rejects.toThrow(
+						'[TIMEOUT]'
+					)
 				})
 
 				it('Rejects the pending promise when wait() is called again', async () => {

--- a/src/__tests__/DOMObserver.test.ts
+++ b/src/__tests__/DOMObserver.test.ts
@@ -94,6 +94,18 @@ describe('DOMObserver', () => {
 					setTimeout(() => controller.abort(), 50)
 					await expect(promise).rejects.toMatchObject({ name: 'AbortError' })
 				})
+
+				it('Sets isObserving to false after the promise resolves', async () => {
+					await instance.wait('#foo')
+					expect(instance.isObserving).toBe(false)
+				})
+
+				it('Does not clear a subsequent watch() when timeout was set', async () => {
+					await instance.wait('#foo', { timeout: 200 })
+					instance.watch('#foo', vi.fn<OnEventCallback>(), { events: [DOMObserver.CHANGE] })
+					await _sleep(250)
+					expect(instance.isObserving).toBe(true)
+				})
 			})
 
 			describe('Element creation and mounting are delayed', () => {


### PR DESCRIPTION
## Summary

- After `wait()` resolved, the `MutationObserver` remained connected and `isObserving` stayed `true`
- Any pending `timeout` timer kept running, risking a `this.clear()` call that could silently kill a `watch()` started in the `.then()` continuation
- Chain `.finally(() => this.clear())` on the returned `Promise` so cleanup runs unconditionally on all settlement paths — resolve, reject, abort signal, timeout — without duplicating logic in `settle()` or `cancel()`

## Test plan

- [x] `isObserving` returns `false` immediately after `wait()` resolves
- [x] A `watch()` started after `await wait({ timeout })` is not cleared when the old timer would have fired
- [x] All 26 existing tests still pass
- [x] Type check passes

Closes #36