### PR TITLE
fix: Throw [TARGET] error on invalid CSS selector instead of propagating SyntaxError

### DIFF
--- a/src/DOMObserver.ts
+++ b/src/DOMObserver.ts
@@ -163,10 +163,8 @@ class DOMObserver {
 		const hasRemove = events.includes(DOMObserver.REMOVE)
 		const hasChange = events.includes(DOMObserver.CHANGE)
 
-		let el: Element | null = null
-		if (isElement(target)) {
-			el = target
-		} else {
+		let el: Element | null = isElement(target) ? target : null
+		if (!el) {
 			try {
 				el = document.querySelector(target as string)
 			} catch {

--- a/src/DOMObserver.ts
+++ b/src/DOMObserver.ts
@@ -163,7 +163,16 @@ class DOMObserver {
 		const hasRemove = events.includes(DOMObserver.REMOVE)
 		const hasChange = events.includes(DOMObserver.CHANGE)
 
-		const el = isElement(target) ? target : document.querySelector(target as string)
+		let el: Element | null = null
+		if (isElement(target)) {
+			el = target
+		} else {
+			try {
+				el = document.querySelector(target as string)
+			} catch {
+				throw new Error(`[TARGET]: "${target}" is not a valid CSS selector`)
+			}
+		}
 		if (el && hasExist) {
 			callback(el, DOMObserver.EXIST)
 		}

--- a/src/__tests__/DOMObserver.test.ts
+++ b/src/__tests__/DOMObserver.test.ts
@@ -74,6 +74,10 @@ describe('DOMObserver', () => {
 					await expect(() => instance.wait('#foo', { events: [] })).rejects.toThrow()
 				})
 
+				it('Rejects with [TARGET] error when selector is invalid', async () => {
+					await expect(instance.wait('##invalid')).rejects.toThrow('[TARGET]')
+				})
+
 				it('Rejects immediately when signal is already aborted', async () => {
 					const controller = new AbortController()
 					controller.abort()
@@ -133,6 +137,11 @@ describe('DOMObserver', () => {
 				expect(onEvent).toHaveBeenCalledWith(el, DOMObserver.EXIST)
 			})
 
+			it('Accepts an Element reference as target', () => {
+				instance.watch(el, onEvent)
+				expect(onEvent).toHaveBeenCalledWith(el, DOMObserver.EXIST)
+			})
+
 			it('Triggers onEvent on every successive attribute change', async () => {
 				instance.watch('#foo', onEvent, { events: [DOMObserver.CHANGE] })
 				_modifyElement('#foo', 'class', 'change1')
@@ -166,6 +175,10 @@ describe('DOMObserver', () => {
 
 			it('Throws when events array is empty', () => {
 				expect(() => instance.watch('#foo', onEvent, { events: [] })).toThrow('[EVENTS]')
+			})
+
+			it('Throws with [TARGET] error when selector is invalid', () => {
+				expect(() => instance.watch('##invalid', onEvent)).toThrow('[TARGET]')
 			})
 
 			it('Rejects the pending wait() promise when watch() is called', async () => {


### PR DESCRIPTION
## Summary

- `document.querySelector()` throws a native `SyntaxError` for malformed selectors (e.g. `"##bad"`, `"[unclosed"`)
- In `watch()` this was an unhandled synchronous exception propagating to the caller with no documentation
- In `wait()` the Promise constructor caught it, but the rejection used a browser-native message inconsistent with the library's `[EVENTS]` / `[TIMEOUT]` error format
- Wrap the `querySelector` call in `_observe()` with a try-catch and throw a `[TARGET]` error, consistent with existing error patterns
- The fix is centralised in `_observe()` — the single call site — covering both `watch()` and `wait()` in one place

## Test plan

- [x] `watch('##invalid', cb)` throws `[TARGET]`
- [x] `wait('##invalid')` rejects with `[TARGET]`
- [x] Element reference path (`isElement(target) === true`) now has explicit coverage — previously hidden in a ternary
- [x] All 29 tests pass
- [x] Coverage: 100% statements / functions / lines, branches up from 92.3% → 93.6%

Closes #37