### PR TITLE
fix: Restrict CHANGE-only observer optimization to Element references

### DIFF
--- a/src/DOMObserver.ts
+++ b/src/DOMObserver.ts
@@ -197,7 +197,7 @@ class DOMObserver {
 			})
 		})
 
-		const observerTarget = hasChange && !hasAdd && !hasRemove && el ? el : document.documentElement
+		const observerTarget = hasChange && !hasAdd && !hasRemove && isElement(target) ? target : document.documentElement
 		this._observer.observe(observerTarget, {
 			subtree: observerTarget === document.documentElement,
 			childList: hasAdd || hasRemove,

--- a/src/__tests__/DOMObserver.test.ts
+++ b/src/__tests__/DOMObserver.test.ts
@@ -173,6 +173,19 @@ describe('DOMObserver', () => {
 				expect(onEvent).toHaveBeenCalledTimes(3)
 			})
 
+			it('Fires CHANGE for all elements matching a class selector, not just the first', async () => {
+				const a = _createElementWithClass('item')
+				const b = _createElementWithClass('item')
+				instance.watch('.item', onEvent, { events: [DOMObserver.CHANGE] })
+				a.setAttribute('data-x', '1')
+				await _sleep()
+				b.setAttribute('data-x', '2')
+				await _sleep()
+				expect(onEvent).toHaveBeenCalledTimes(2)
+				expect(onEvent).toHaveBeenCalledWith(a, DOMObserver.CHANGE, { attributeName: 'data-x', oldValue: null })
+				expect(onEvent).toHaveBeenCalledWith(b, DOMObserver.CHANGE, { attributeName: 'data-x', oldValue: null })
+			})
+
 			it('Throws when events array is empty', () => {
 				expect(() => instance.watch('#foo', onEvent, { events: [] })).toThrow('[EVENTS]')
 			})


### PR DESCRIPTION
## Summary

- When `target` was a string selector and the first matching element existed in the DOM, the CHANGE-only optimization set `observerTarget` to that first element with `subtree: false`
- Sibling elements matching the same selector were silently ignored — their attribute changes never reached the MutationObserver callback since they are not in the first element's subtree
- Restrict the optimization to `isElement(target)` only: when the exact node is known, observing it directly with `subtree: false` is correct; for string selectors, always use `document.documentElement` + `subtree: true` so all matching elements are covered

## Test plan

- [x] New test: CHANGE fires for all elements matching `.item`, not just the first one — fails on `main`, passes with the fix
- [x] All 30 existing tests pass
- [x] Coverage: 100% statements / functions / lines
- [x] Demo: new Tags section with three `.tag` elements, each togglable independently, all logging to output via a single `.tag` CHANGE observer

Closes #38