### PR TITLE
feat: make clear() return this to enable method chaining

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,10 +161,13 @@ console.log(observer.isObserving) // false
 
 ### Discard observation
 
-Call the `clear` method to discard observation:
+Call the `clear` method to discard observation. It returns `this`, allowing method chaining:
 
 ```javascript
 observer.clear()
+
+// Stop and immediately restart with a different target
+observer.clear().watch('#bar', onEvent)
 ```
 
 > **Note:** Calling `wait()` on an instance that already has a pending Promise will automatically reject the previous Promise with an `[ABORT]` error before starting the new observation. Handle this rejection if necessary:

--- a/src/DOMObserver.ts
+++ b/src/DOMObserver.ts
@@ -197,7 +197,8 @@ class DOMObserver {
 			})
 		})
 
-		const observerTarget = hasChange && !hasAdd && !hasRemove && isElement(target) ? target : document.documentElement
+		const observerTarget =
+			hasChange && !hasAdd && !hasRemove && isElement(target) ? target : document.documentElement
 		this._observer.observe(observerTarget, {
 			subtree: observerTarget === document.documentElement,
 			childList: hasAdd || hasRemove,

--- a/src/DOMObserver.ts
+++ b/src/DOMObserver.ts
@@ -207,7 +207,7 @@ class DOMObserver {
 		})
 	}
 
-	clear(): void {
+	clear(): this {
 		if (this._signal && this._abortHandler) {
 			this._signal.removeEventListener('abort', this._abortHandler)
 		}
@@ -217,6 +217,7 @@ class DOMObserver {
 		this._observer?.disconnect()
 		this._observer = null
 		clearTimeout(this._timeout)
+		return this
 	}
 }
 

--- a/src/DOMObserver.ts
+++ b/src/DOMObserver.ts
@@ -283,6 +283,8 @@ class DOMObserver {
 	 * Stops the active observation and resets all internal state.
 	 *
 	 * Safe to call at any time — including when no observation is active.
+	 *
+	 * @returns The instance, enabling method chaining.
 	 */
 	clear(): this {
 		if (this._signal && this._abortHandler) {

--- a/src/__tests__/DOMObserver.test.ts
+++ b/src/__tests__/DOMObserver.test.ts
@@ -261,4 +261,10 @@ describe('DOMObserver', () => {
 			})
 		})
 	})
+
+	describe('clear', () => {
+		it('Returns the instance for chaining', () => {
+			expect(instance.clear()).toBe(instance)
+		})
+	})
 })


### PR DESCRIPTION
## Summary

Makes `clear()` return `this` instead of `void`, enabling fluent method chaining consistent with `watch()`.

## Changes

- `src/DOMObserver.ts` — changed return type of `clear()` from `void` to `this` and added `return this`
- `src/__tests__/DOMObserver.test.ts` — added test asserting `clear()` returns the instance
- `README.md` — updated documentation to mention chaining and added example

## Test plan

- [x] `yarn test:ci` passes (31 tests, 100% coverage)
- [x] `yarn build` succeeds

## Notes

No breaking change — existing call sites that ignore the return value continue to work unchanged.

Closes #40