### PR TITLE
feat: export error message constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,24 +194,21 @@ observer.clear().watch('#bar', onEvent)
 > observer.watch('#baz', onEvent)  // also rejects a pending wait() with [ABORT]
 > ```
 
-### Error constants
+## Error constants
 
 The library exports a `DOMObserverErrors` object and a `DOMObserverErrorCode` type for reliable error handling without fragile string matching:
 
 ```typescript
-import { DOMObserver, DOMObserverErrors, type DOMObserverErrorCode } from '@untemps/dom-observer'
+import { DOMObserver, DOMObserverErrors } from '@untemps/dom-observer'
 
 try {
     await observer.wait('#foo', { timeout: 500 })
 } catch (e) {
-    const code = (e as Error).message.split(':')[0] as DOMObserverErrorCode
-    switch (code) {
-        case DOMObserverErrors.TIMEOUT:
-            // handle timeout
-            break
-        case DOMObserverErrors.ABORT:
-            // replaced by another observation
-            break
+    const message = (e as Error).message
+    if (message.startsWith(DOMObserverErrors.TIMEOUT)) {
+        // handle timeout
+    } else if (message.startsWith(DOMObserverErrors.ABORT)) {
+        // replaced by another observation
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -183,14 +183,45 @@ observer.clear().watch('#bar', onEvent)
 > **Note:** Calling `wait()` or `watch()` on an instance that already has a pending `wait()` Promise will automatically reject that Promise with an `[ABORT]` error before starting the new observation. Handle this rejection if necessary:
 >
 > ```javascript
+> import { DOMObserver, DOMObserverErrors } from '@untemps/dom-observer'
+>
 > const observer = new DOMObserver()
 > observer.wait('#foo').catch((err) => {
->     if (err.message.startsWith('[ABORT]')) return // replaced by a new observation
+>     if (err.message.startsWith(DOMObserverErrors.ABORT)) return // replaced by a new observation
 >     throw err
 > })
 > observer.wait('#bar')  // previous promise is rejected with [ABORT]
 > observer.watch('#baz', onEvent)  // also rejects a pending wait() with [ABORT]
 > ```
+
+### Error constants
+
+The library exports a `DOMObserverErrors` object and a `DOMObserverErrorCode` type for reliable error handling without fragile string matching:
+
+```typescript
+import { DOMObserver, DOMObserverErrors, type DOMObserverErrorCode } from '@untemps/dom-observer'
+
+try {
+    await observer.wait('#foo', { timeout: 500 })
+} catch (e) {
+    const code = (e as Error).message.split(':')[0] as DOMObserverErrorCode
+    switch (code) {
+        case DOMObserverErrors.TIMEOUT:
+            // handle timeout
+            break
+        case DOMObserverErrors.ABORT:
+            // replaced by another observation
+            break
+    }
+}
+```
+
+| Constant | Value | Thrown by |
+|---|---|---|
+| `DOMObserverErrors.TIMEOUT` | `'[TIMEOUT]'` | `wait()`, `watch()` when `timeout` elapses |
+| `DOMObserverErrors.ABORT` | `'[ABORT]'` | `wait()` when replaced by a new call |
+| `DOMObserverErrors.EVENTS` | `'[EVENTS]'` | `wait()`, `watch()` when `events` array is empty |
+| `DOMObserverErrors.TARGET` | `'[TARGET]'` | `wait()`, `watch()` when `target` is an invalid CSS selector |
 
 ## Example
 

--- a/src/DOMObserver.ts
+++ b/src/DOMObserver.ts
@@ -1,5 +1,5 @@
-import isElement from './utils/isElement'
 import { DOMObserverErrors } from './DOMObserverErrors'
+import isElement from './utils/isElement'
 
 /** A CSS selector string or a direct DOM Element reference used to identify the observed target. */
 export type DOMTarget = Element | string
@@ -146,7 +146,12 @@ class DOMObserver {
 
 			if (timeout > 0) {
 				this._timeout = setTimeout(
-					() => cancel(new Error(`${DOMObserverErrors.TIMEOUT}: Element ${target} cannot be found after ${timeout}ms`)),
+					() =>
+						cancel(
+							new Error(
+								`${DOMObserverErrors.TIMEOUT}: Element ${target} cannot be found after ${timeout}ms`
+							)
+						),
 					timeout
 				)
 			}
@@ -216,7 +221,9 @@ class DOMObserver {
 		if (timeout > 0) {
 			this._timeout = setTimeout(() => {
 				this.clear()
-				onError?.(new Error(`${DOMObserverErrors.TIMEOUT}: Element ${target} cannot be found after ${timeout}ms`))
+				onError?.(
+					new Error(`${DOMObserverErrors.TIMEOUT}: Element ${target} cannot be found after ${timeout}ms`)
+				)
 			}, timeout)
 		}
 

--- a/src/DOMObserver.ts
+++ b/src/DOMObserver.ts
@@ -1,4 +1,5 @@
 import isElement from './utils/isElement'
+import { DOMObserverErrors } from './DOMObserverErrors'
 
 /** A CSS selector string or a direct DOM Element reference used to identify the observed target. */
 export type DOMTarget = Element | string
@@ -106,14 +107,14 @@ class DOMObserver {
 		{ events = DOMObserver.EVENTS, timeout = 0, attributeFilter = undefined, signal = undefined }: WaitOptions = {}
 	): Promise<WaitResult> {
 		if (!events?.length) {
-			return Promise.reject(new Error('[EVENTS]: events array cannot be empty'))
+			return Promise.reject(new Error(`${DOMObserverErrors.EVENTS}: events array cannot be empty`))
 		}
 
 		if (signal?.aborted) {
 			return Promise.reject(signal.reason ?? new DOMException('Aborted', 'AbortError'))
 		}
 
-		this._pendingReject?.(new Error('[ABORT]: Observation replaced by a new wait() call'))
+		this._pendingReject?.(new Error(`${DOMObserverErrors.ABORT}: Observation replaced by a new wait() call`))
 		this._pendingReject = null
 		this.clear()
 
@@ -145,7 +146,7 @@ class DOMObserver {
 
 			if (timeout > 0) {
 				this._timeout = setTimeout(
-					() => cancel(new Error(`[TIMEOUT]: Element ${target} cannot be found after ${timeout}ms`)),
+					() => cancel(new Error(`${DOMObserverErrors.TIMEOUT}: Element ${target} cannot be found after ${timeout}ms`)),
 					timeout
 				)
 			}
@@ -187,14 +188,14 @@ class DOMObserver {
 		}: WatchOptions = {}
 	): this {
 		if (!events?.length) {
-			throw new Error('[EVENTS]: events array cannot be empty')
+			throw new Error(`${DOMObserverErrors.EVENTS}: events array cannot be empty`)
 		}
 
 		if (signal?.aborted) {
 			return this
 		}
 
-		this._pendingReject?.(new Error('[ABORT]: Observation replaced by a new watch() call'))
+		this._pendingReject?.(new Error(`${DOMObserverErrors.ABORT}: Observation replaced by a new watch() call`))
 		this._pendingReject = null
 		this.clear()
 
@@ -215,7 +216,7 @@ class DOMObserver {
 		if (timeout > 0) {
 			this._timeout = setTimeout(() => {
 				this.clear()
-				onError?.(new Error(`[TIMEOUT]: Element ${target} cannot be found after ${timeout}ms`))
+				onError?.(new Error(`${DOMObserverErrors.TIMEOUT}: Element ${target} cannot be found after ${timeout}ms`))
 			}, timeout)
 		}
 
@@ -239,7 +240,7 @@ class DOMObserver {
 			try {
 				el = document.querySelector(target as string)
 			} catch {
-				throw new Error(`[TARGET]: "${target}" is not a valid CSS selector`)
+				throw new Error(`${DOMObserverErrors.TARGET}: "${target}" is not a valid CSS selector`)
 			}
 		}
 		if (el && hasExist) {

--- a/src/DOMObserverErrors.ts
+++ b/src/DOMObserverErrors.ts
@@ -1,0 +1,8 @@
+export const DOMObserverErrors = {
+	TIMEOUT: '[TIMEOUT]',
+	ABORT: '[ABORT]',
+	EVENTS: '[EVENTS]',
+	TARGET: '[TARGET]',
+} as const
+
+export type DOMObserverErrorCode = (typeof DOMObserverErrors)[keyof typeof DOMObserverErrors]

--- a/src/__tests__/DOMObserver.test.ts
+++ b/src/__tests__/DOMObserver.test.ts
@@ -268,3 +268,12 @@ describe('DOMObserver', () => {
 		})
 	})
 })
+
+describe('DOMObserverErrors', () => {
+	it('Exports expected error code values', () => {
+		expect(DOMObserverErrors.TIMEOUT).toBe('[TIMEOUT]')
+		expect(DOMObserverErrors.ABORT).toBe('[ABORT]')
+		expect(DOMObserverErrors.EVENTS).toBe('[EVENTS]')
+		expect(DOMObserverErrors.TARGET).toBe('[TARGET]')
+	})
+})

--- a/src/__tests__/DOMObserver.test.ts
+++ b/src/__tests__/DOMObserver.test.ts
@@ -1,4 +1,4 @@
-import { DOMObserver, type OnEventCallback } from '../index'
+import { DOMObserver, DOMObserverErrors, type OnEventCallback } from '../index'
 
 describe('DOMObserver', () => {
 	let instance: DOMObserver
@@ -60,14 +60,14 @@ describe('DOMObserver', () => {
 
 				it('Rejects promise when an element is not found after timeout is elapsed', async () => {
 					await expect(instance.wait('#bar', { events: [DOMObserver.ADD], timeout: 50 })).rejects.toThrow(
-						'[TIMEOUT]'
+						DOMObserverErrors.TIMEOUT
 					)
 				})
 
 				it('Rejects the pending promise when wait() is called again', async () => {
 					const first = instance.wait('#bar', { events: [DOMObserver.ADD] })
 					instance.wait('#baz', { events: [DOMObserver.ADD] })
-					await expect(first).rejects.toThrow('[ABORT]')
+					await expect(first).rejects.toThrow(DOMObserverErrors.ABORT)
 				})
 
 				it('Throws when events array is empty', async () => {
@@ -75,7 +75,7 @@ describe('DOMObserver', () => {
 				})
 
 				it('Rejects with [TARGET] error when selector is invalid', async () => {
-					await expect(instance.wait('##invalid')).rejects.toThrow('[TARGET]')
+					await expect(instance.wait('##invalid')).rejects.toThrow(DOMObserverErrors.TARGET)
 				})
 
 				it('Rejects immediately when signal is already aborted', async () => {
@@ -187,17 +187,17 @@ describe('DOMObserver', () => {
 			})
 
 			it('Throws when events array is empty', () => {
-				expect(() => instance.watch('#foo', onEvent, { events: [] })).toThrow('[EVENTS]')
+				expect(() => instance.watch('#foo', onEvent, { events: [] })).toThrow(DOMObserverErrors.EVENTS)
 			})
 
 			it('Throws with [TARGET] error when selector is invalid', () => {
-				expect(() => instance.watch('##invalid', onEvent)).toThrow('[TARGET]')
+				expect(() => instance.watch('##invalid', onEvent)).toThrow(DOMObserverErrors.TARGET)
 			})
 
 			it('Rejects the pending wait() promise when watch() is called', async () => {
 				const pending = instance.wait('#bar', { events: [DOMObserver.ADD] })
 				instance.watch('#foo', onEvent)
-				await expect(pending).rejects.toThrow('[ABORT]')
+				await expect(pending).rejects.toThrow(DOMObserverErrors.ABORT)
 			})
 
 			it('Returns the instance for chaining', () => {
@@ -231,7 +231,7 @@ describe('DOMObserver', () => {
 				await _sleep(100)
 				expect(onEvent).not.toHaveBeenCalled()
 				expect(onError).toHaveBeenCalledOnce()
-				expect((onError.mock.calls[0][0] as Error).message).toMatch('[TIMEOUT]')
+				expect((onError.mock.calls[0][0] as Error).message).toMatch(DOMObserverErrors.TIMEOUT)
 			})
 
 			it('Does not call onError when a mutation occurs before timeout', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,3 +8,5 @@ export type {
 	WatchOptions,
 } from './DOMObserver'
 export { default as DOMObserver } from './DOMObserver'
+export { DOMObserverErrors } from './DOMObserverErrors'
+export type { DOMObserverErrorCode } from './DOMObserverErrors'

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,5 +8,5 @@ export type {
 	WatchOptions,
 } from './DOMObserver'
 export { default as DOMObserver } from './DOMObserver'
-export { DOMObserverErrors } from './DOMObserverErrors'
 export type { DOMObserverErrorCode } from './DOMObserverErrors'
+export { DOMObserverErrors } from './DOMObserverErrors'


### PR DESCRIPTION
## Summary

Exports a `DOMObserverErrors` constant object and a `DOMObserverErrorCode` type from the library, so consumers can handle errors reliably without fragile string matching. Internally, all inline error strings have been replaced by references to these constants.

## Changes

- `src/DOMObserverErrors.ts` *(new)* — defines `DOMObserverErrors` (`TIMEOUT`, `ABORT`, `EVENTS`, `TARGET`) and `DOMObserverErrorCode`
- `src/DOMObserver.ts` — replaces all inline `'[TIMEOUT]'` / `'[ABORT]'` / `'[EVENTS]'` / `'[TARGET]'` strings with the constants
- `src/index.ts` — re-exports `DOMObserverErrors` and `DOMObserverErrorCode`
- `src/__tests__/DOMObserver.test.ts` — updates all error string matchers to use `DOMObserverErrors.*`
- `README.md` — adds an *Error constants* section with usage table and example; updates the ABORT note to use the constant

## Test plan

- [x] `yarn test:ci` passes (31 tests, 100% coverage)
- [x] `yarn build` succeeds — `DOMObserverErrors` and `DOMObserverErrorCode` are present in the generated `.d.ts`

Closes #41