### PR TITLE
test: add coverage for the attributeFilter option

### DIFF
--- a/src/__tests__/DOMObserver.test.ts
+++ b/src/__tests__/DOMObserver.test.ts
@@ -58,6 +58,18 @@ describe('DOMObserver', () => {
 					expect(oldValue).toBe('bar')
 				})
 
+				it('Resolves only when a filtered attribute changes', async () => {
+					setTimeout(() => {
+						_modifyElement('#foo', 'data-ignored', 'x')
+						_modifyElement('#foo', 'data-watched', 'y')
+					}, 50)
+					const { options } = await instance.wait('#foo', {
+						events: [DOMObserver.CHANGE],
+						attributeFilter: ['data-watched'],
+					})
+					expect(options?.attributeName).toBe('data-watched')
+				})
+
 				it('Rejects promise when an element is not found after timeout is elapsed', async () => {
 					await expect(instance.wait('#bar', { events: [DOMObserver.ADD], timeout: 50 })).rejects.toThrow(
 						DOMObserverErrors.TIMEOUT
@@ -184,6 +196,22 @@ describe('DOMObserver', () => {
 				expect(onEvent).toHaveBeenCalledTimes(2)
 				expect(onEvent).toHaveBeenCalledWith(a, DOMObserver.CHANGE, { attributeName: 'data-x', oldValue: null })
 				expect(onEvent).toHaveBeenCalledWith(b, DOMObserver.CHANGE, { attributeName: 'data-x', oldValue: null })
+			})
+
+			it('Only fires for attributes in the filter list', async () => {
+				instance.watch('#foo', onEvent, {
+					events: [DOMObserver.CHANGE],
+					attributeFilter: ['data-watched'],
+				})
+				_modifyElement('#foo', 'data-ignored', 'x')
+				await _sleep()
+				_modifyElement('#foo', 'data-watched', 'y')
+				await _sleep()
+				expect(onEvent).toHaveBeenCalledOnce()
+				expect(onEvent).toHaveBeenCalledWith(el, DOMObserver.CHANGE, {
+					attributeName: 'data-watched',
+					oldValue: null,
+				})
 			})
 
 			it('Throws when events array is empty', () => {


### PR DESCRIPTION
## Summary

Adds two tests to cover the `attributeFilter` option, which was passed to the native `MutationObserver.observe()` call but never exercised by the test suite. A regression in this path would previously pass CI undetected.

## Changes

- `src/__tests__/DOMObserver.test.ts` — two new tests:
  - `wait()`: verifies that only the listed attribute resolves the promise, and that an unlisted attribute is ignored
  - `watch()`: verifies that `onEvent` fires exactly once (for the listed attribute), not for the unlisted one

## Test plan

- [x] `yarn test:ci` passes (34 tests, 100% coverage)

Closes #43