### PR TITLE
feat: add once option to watch() for callback-style one-shot observation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ listObserver.watch('.list-item', (node, event) => {
 
 Unlike `wait`, `watch` does not return a Promise. It returns `this`, allowing method chaining. Call `clear()` to stop the observation.
 
+Pass `once: true` to stop the observation automatically after the first matching event, without needing to call `clear()` manually:
+
+```javascript
+observer.watch('#foo', (node, event) => {
+	doSomething(node)  // called exactly once
+}, { events: [DOMObserver.ADD], once: true })
+```
+
 Pass a `timeout` to automatically stop the observation if no matching mutation occurs within the allotted time:
 
 ```javascript
@@ -77,6 +85,7 @@ observer.watch('#foo', (node, event) => {
 | - `timeout`         | Number            | Duration (in ms) after which observation stops if no matching mutation occurred. Triggers `onError` when elapsed.                                        |
 | - `onError`         | Function          | Callback triggered when `timeout` elapses with no matching mutation                                                                                      |
 | - `signal`          | AbortSignal       | An `AbortSignal` to stop the observation. If already aborted, `watch()` returns immediately without observing.                                           |
+| - `once`            | Boolean           | When `true`, automatically calls `clear()` after the first matching event. Defaults to `false`.                                                          |
 
 #### `onEvent` callback arguments
 

--- a/src/DOMObserver.ts
+++ b/src/DOMObserver.ts
@@ -223,6 +223,12 @@ class DOMObserver {
 				clearTimeout(this._timeout)
 				wrapped(...args)
 			}
+			this._timeout = setTimeout(() => {
+				this.clear()
+				onError?.(
+					new Error(`${DOMObserverErrors.TIMEOUT}: Element ${target} cannot be found after ${timeout}ms`)
+				)
+			}, timeout)
 		}
 		if (once) {
 			const wrapped = callback
@@ -230,15 +236,6 @@ class DOMObserver {
 				this.clear()
 				wrapped(...args)
 			}
-		}
-
-		if (timeout > 0) {
-			this._timeout = setTimeout(() => {
-				this.clear()
-				onError?.(
-					new Error(`${DOMObserverErrors.TIMEOUT}: Element ${target} cannot be found after ${timeout}ms`)
-				)
-			}, timeout)
 		}
 
 		this._observe(target, callback, { events, attributeFilter })

--- a/src/DOMObserver.ts
+++ b/src/DOMObserver.ts
@@ -61,6 +61,8 @@ export interface WatchOptions {
 	onError?: (error: Error) => void
 	/** When provided, aborting the signal stops observation immediately. */
 	signal?: AbortSignal
+	/** When `true`, automatically calls `clear()` after the first matching event. */
+	once?: boolean
 }
 
 class DOMObserver {
@@ -174,6 +176,9 @@ class DOMObserver {
 	 * When `timeout` is set, the observation stops automatically after the first matching mutation —
 	 * subsequent mutations will not fire `onEvent`.
 	 *
+	 * When `once` is set, the observation stops automatically after the first matching mutation,
+	 * equivalent to calling `clear()` manually inside `onEvent`.
+	 *
 	 * @param target - CSS selector or Element to observe.
 	 * @param onEvent - Callback invoked on every matching event.
 	 * @param options - Observation options.
@@ -190,6 +195,7 @@ class DOMObserver {
 			timeout = 0,
 			onError = undefined,
 			signal = undefined,
+			once = false,
 		}: WatchOptions = {}
 	): this {
 		if (!events?.length) {
@@ -210,13 +216,21 @@ class DOMObserver {
 			signal.addEventListener('abort', this._abortHandler, { once: true })
 		}
 
-		const callback: OnEventCallback =
-			timeout > 0
-				? (...args) => {
-						clearTimeout(this._timeout)
-						onEvent(...args)
-					}
-				: onEvent
+		let callback: OnEventCallback = onEvent
+		if (timeout > 0) {
+			const wrapped = callback
+			callback = (...args) => {
+				clearTimeout(this._timeout)
+				wrapped(...args)
+			}
+		}
+		if (once) {
+			const wrapped = callback
+			callback = (...args) => {
+				this.clear()
+				wrapped(...args)
+			}
+		}
 
 		if (timeout > 0) {
 			this._timeout = setTimeout(() => {

--- a/src/__tests__/DOMObserver.test.ts
+++ b/src/__tests__/DOMObserver.test.ts
@@ -278,6 +278,32 @@ describe('DOMObserver', () => {
 				await _sleep(100)
 				expect(instance.isObserving).toBe(false)
 			})
+
+			it('Fires onEvent only once when once is true', async () => {
+				instance.watch('#foo', onEvent, { events: [DOMObserver.CHANGE], once: true })
+				_modifyElement('#foo', 'class', 'change1')
+				await _sleep()
+				_modifyElement('#foo', 'class', 'change2')
+				await _sleep()
+				expect(onEvent).toHaveBeenCalledOnce()
+			})
+
+			it('Sets isObserving to false after the first event when once is true', async () => {
+				instance.watch('#foo', onEvent, { events: [DOMObserver.CHANGE], once: true })
+				_modifyElement('#foo', 'class', 'change1')
+				await _sleep()
+				expect(instance.isObserving).toBe(false)
+			})
+
+			it('Cancels timeout after the first event when once and timeout are both set', async () => {
+				const onError = vi.fn()
+				instance.watch('#foo', onEvent, { events: [DOMObserver.CHANGE], once: true, timeout: 200, onError })
+				_modifyElement('#foo', 'class', 'change1')
+				await _sleep()
+				expect(onEvent).toHaveBeenCalledOnce()
+				await _sleep(250)
+				expect(onError).not.toHaveBeenCalled()
+			})
 		})
 
 		describe('Element creation and mounting are delayed', () => {


### PR DESCRIPTION
## Summary

Adds a `once?: boolean` option to `watch()` that automatically calls `clear()` after the first matching event. This provides one-shot callback semantics without requiring callers to manually stop the observer, and without the Promise overhead of `wait()`.

## Changes

- `src/DOMObserver.ts` — adds `once?: boolean` to `WatchOptions` with JSDoc; `watch()` composes the callback stepwise: timeout wrapping first, then once wrapping, so `clearTimeout` is always called before `clear()` when both options are set
- `src/__tests__/DOMObserver.test.ts` — three new tests: fires only once, sets `isObserving` to false, cancels timeout when `once + timeout` are combined
- `README.md` — adds `once` row to the options table, adds a usage example

## Test plan

- [x] `yarn test:ci` passes (37 tests, 100% coverage)
- [x] `yarn build` succeeds — `once` appears in the generated `.d.ts`

Closes #44