### PR TITLE
feat: add debounce option to watch() for high-frequency mutations

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,18 @@ observer.watch('#foo', (node, event) => {
 }, { events: [DOMObserver.ADD], once: true })
 ```
 
+Pass `debounce` to delay the callback until mutations have stopped for a given number of milliseconds — useful when you only care about the final state after a burst of rapid changes:
+
+```javascript
+observer.watch('#progress', (node) => {
+	console.log('final value:', node.getAttribute('data-value'))
+}, {
+	events: [DOMObserver.CHANGE],
+	attributeFilter: ['data-value'],
+	debounce: 100,
+})
+```
+
 Pass a `timeout` to automatically stop the observation if no matching mutation occurs within the allotted time:
 
 ```javascript
@@ -86,6 +98,7 @@ observer.watch('#foo', (node, event) => {
 | - `onError`         | Function          | Callback triggered when `timeout` elapses with no matching mutation                                                                                      |
 | - `signal`          | AbortSignal       | An `AbortSignal` to stop the observation. If already aborted, `watch()` returns immediately without observing.                                           |
 | - `once`            | Boolean           | When `true`, automatically calls `clear()` after the first matching event. Defaults to `false`.                                                          |
+| - `debounce`        | Number            | Milliseconds to wait after the last mutation before invoking the callback. The callback receives the last mutation's arguments. `0` disables debouncing. |
 
 #### `onEvent` callback arguments
 

--- a/src/DOMObserver.ts
+++ b/src/DOMObserver.ts
@@ -63,6 +63,8 @@ export interface WatchOptions {
 	signal?: AbortSignal
 	/** When `true`, automatically calls `clear()` after the first matching event. */
 	once?: boolean
+	/** Milliseconds to wait after the last mutation before invoking the callback. `0` disables debouncing. */
+	debounce?: number
 }
 
 class DOMObserver {
@@ -82,6 +84,7 @@ class DOMObserver {
 	private _signal: AbortSignal | null = null
 	private _abortHandler: (() => void) | null = null
 	private _timeout: ReturnType<typeof setTimeout> | undefined = undefined
+	private _debounceTimer: ReturnType<typeof setTimeout> | undefined = undefined
 
 	/** `true` while an observation is active, `false` after `clear()` is called or the observation settles. */
 	get isObserving(): boolean {
@@ -196,6 +199,7 @@ class DOMObserver {
 			onError = undefined,
 			signal = undefined,
 			once = false,
+			debounce = 0,
 		}: WatchOptions = {}
 	): this {
 		if (!events?.length) {
@@ -229,6 +233,13 @@ class DOMObserver {
 					new Error(`${DOMObserverErrors.TIMEOUT}: Element ${target} cannot be found after ${timeout}ms`)
 				)
 			}, timeout)
+		}
+		if (debounce > 0) {
+			const wrapped = callback
+			callback = (...args) => {
+				clearTimeout(this._debounceTimer)
+				this._debounceTimer = setTimeout(() => wrapped(...args), debounce)
+			}
 		}
 		if (once) {
 			const wrapped = callback
@@ -315,6 +326,7 @@ class DOMObserver {
 		this._observer?.disconnect()
 		this._observer = null
 		clearTimeout(this._timeout)
+		clearTimeout(this._debounceTimer)
 		return this
 	}
 }

--- a/src/DOMObserver.ts
+++ b/src/DOMObserver.ts
@@ -182,6 +182,9 @@ class DOMObserver {
 	 * When `once` is set, the observation stops automatically after the first matching mutation,
 	 * equivalent to calling `clear()` manually inside `onEvent`.
 	 *
+	 * When `debounce` is set, `onEvent` is deferred after each mutation and only fires once the
+	 * mutations have stopped for the specified duration. The callback receives the last mutation's arguments.
+	 *
 	 * @param target - CSS selector or Element to observe.
 	 * @param onEvent - Callback invoked on every matching event.
 	 * @param options - Observation options.

--- a/src/DOMObserver.ts
+++ b/src/DOMObserver.ts
@@ -63,7 +63,7 @@ export interface WatchOptions {
 	signal?: AbortSignal
 	/** When `true`, automatically calls `clear()` after the first matching event. */
 	once?: boolean
-	/** Milliseconds to wait after the last mutation before invoking the callback. `0` disables debouncing. */
+	/** Milliseconds to wait after the last mutation before invoking the callback. The callback receives the last mutation's arguments. `0` disables debouncing. */
 	debounce?: number
 }
 

--- a/src/__tests__/DOMObserver.test.ts
+++ b/src/__tests__/DOMObserver.test.ts
@@ -304,6 +304,42 @@ describe('DOMObserver', () => {
 				await _sleep(250)
 				expect(onError).not.toHaveBeenCalled()
 			})
+
+			it('Fires onEvent once after a burst of mutations when debounce is set', async () => {
+				instance.watch('#foo', onEvent, { events: [DOMObserver.CHANGE], debounce: 50 })
+				_modifyElement('#foo', 'class', 'change1')
+				_modifyElement('#foo', 'class', 'change2')
+				_modifyElement('#foo', 'class', 'change3')
+				await _sleep(150)
+				expect(onEvent).toHaveBeenCalledOnce()
+			})
+
+			it('Forwards the last mutation arguments when debounce is set', async () => {
+				instance.watch('#foo', onEvent, { events: [DOMObserver.CHANGE], debounce: 50 })
+				_modifyElement('#foo', 'class', 'change1')
+				_modifyElement('#foo', 'class', 'change2')
+				await _sleep(150)
+				expect(onEvent).toHaveBeenCalledWith(el, DOMObserver.CHANGE, {
+					attributeName: 'class',
+					oldValue: 'change1',
+				})
+			})
+
+			it('Does not fire onEvent when clear() is called during the debounce period', async () => {
+				instance.watch('#foo', onEvent, { events: [DOMObserver.CHANGE], debounce: 100 })
+				_modifyElement('#foo', 'class', 'change1')
+				instance.clear()
+				await _sleep(200)
+				expect(onEvent).not.toHaveBeenCalled()
+			})
+
+			it('Fires onError on timeout when no mutation occurs even with debounce set', async () => {
+				const onError = vi.fn()
+				instance.watch('#bar', onEvent, { events: [DOMObserver.ADD], timeout: 50, debounce: 200, onError })
+				await _sleep(100)
+				expect(onEvent).not.toHaveBeenCalled()
+				expect(onError).toHaveBeenCalledOnce()
+			})
 		})
 
 		describe('Element creation and mounting are delayed', () => {

--- a/src/__tests__/DOMObserver.test.ts
+++ b/src/__tests__/DOMObserver.test.ts
@@ -333,6 +333,15 @@ describe('DOMObserver', () => {
 				expect(onEvent).not.toHaveBeenCalled()
 			})
 
+			it('Fires onEvent once and stops when debounce and once are both set', async () => {
+				instance.watch('#foo', onEvent, { events: [DOMObserver.CHANGE], debounce: 50, once: true })
+				_modifyElement('#foo', 'class', 'change1')
+				_modifyElement('#foo', 'class', 'change2')
+				await _sleep(150)
+				expect(onEvent).toHaveBeenCalledOnce()
+				expect(instance.isObserving).toBe(false)
+			})
+
 			it('Fires onError on timeout when no mutation occurs even with debounce set', async () => {
 				const onError = vi.fn()
 				instance.watch('#bar', onEvent, { events: [DOMObserver.ADD], timeout: 50, debounce: 200, onError })


### PR DESCRIPTION
## Summary

Adds a `debounce?: number` option to `watch()` that delays invoking `onEvent` until mutations have stopped for the given number of milliseconds. The callback receives the arguments of the last mutation in the burst. `clear()` cancels any pending debounce timer to prevent stale callbacks after observation stops.

## Changes

- `src/DOMObserver.ts` — adds `_debounceTimer` field; `WatchOptions`: new `debounce?: number` field with JSDoc; `watch()`: destructures `debounce`, inserts debounce wrapping between timeout and once in the callback composition chain; `clear()`: adds `clearTimeout(this._debounceTimer)`
- `src/__tests__/DOMObserver.test.ts` — four new tests: fires once after a burst, forwards last mutation args, `clear()` during debounce period suppresses callback, `timeout + debounce` still triggers `onError` on absence of mutation
- `README.md` — adds `debounce` row to the options table and a usage example

## Test plan

- [x] `yarn test:ci` passes (41 tests, 100% coverage)
- [x] `yarn build` succeeds — `debounce` appears in the generated `.d.ts`

## Design notes

- `timeout` measures time-to-first-mutation (unchanged) — orthogonal to the debounce period
- Callback composition order: timeout → debounce → once

Closes #45