### PR TITLE
feat: add root option to restrict observation scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ observer.watch('#foo', (node, event) => {
 | - `signal`          | AbortSignal       | An `AbortSignal` to stop the observation. If already aborted, `watch()` returns immediately without observing.                                           |
 | - `once`            | Boolean           | When `true`, automatically calls `clear()` after the first matching event. Defaults to `false`.                                                          |
 | - `debounce`        | Number            | Milliseconds to wait after the last mutation before invoking the callback. The callback receives the last mutation's arguments. `0` disables debouncing. |
+| - `root`            | Element or String | DOM element or CSS selector to use as the observation root. Only mutations within this subtree are observed. Defaults to `document.documentElement`.     |
 
 #### `onEvent` callback arguments
 
@@ -149,6 +150,7 @@ Once the first matching mutation occurs, the Promise resolves and the observatio
 | - `timeout`         | Number            | Duration (in ms) before rejecting the Promise with a `[TIMEOUT]` error. `0` disables the timeout.                                                       |
 | - `attributeFilter` | Array             | List of attribute names to observe (DOMObserver.CHANGE event only)                                                                                       |
 | - `signal`          | AbortSignal       | An `AbortSignal` to cancel the observation. If already aborted, the Promise rejects immediately with an `AbortError`.                                    |
+| - `root`            | Element or String | DOM element or CSS selector to use as the observation root. Only mutations within this subtree are observed. Defaults to `document.documentElement`.     |
 
 #### Resolved value
 

--- a/src/DOMObserver.ts
+++ b/src/DOMObserver.ts
@@ -44,6 +44,8 @@ export interface WaitOptions {
 	attributeFilter?: string[]
 	/** When provided, aborting the signal rejects the Promise with an `AbortError`. */
 	signal?: AbortSignal
+	/** DOM element or CSS selector to use as the observation root. Defaults to `document.documentElement`. */
+	root?: DOMTarget
 }
 
 /** Options accepted by `watch()`. */
@@ -65,6 +67,8 @@ export interface WatchOptions {
 	once?: boolean
 	/** Milliseconds to wait after the last mutation before invoking the callback. The callback receives the last mutation's arguments. `0` disables debouncing. */
 	debounce?: number
+	/** DOM element or CSS selector to use as the observation root. Defaults to `document.documentElement`. */
+	root?: DOMTarget
 }
 
 class DOMObserver {
@@ -109,7 +113,13 @@ class DOMObserver {
 	 */
 	wait(
 		target: DOMTarget,
-		{ events = DOMObserver.EVENTS, timeout = 0, attributeFilter = undefined, signal = undefined }: WaitOptions = {}
+		{
+			events = DOMObserver.EVENTS,
+			timeout = 0,
+			attributeFilter = undefined,
+			signal = undefined,
+			root = undefined,
+		}: WaitOptions = {}
 	): Promise<WaitResult> {
 		if (!events?.length) {
 			return Promise.reject(new Error(`${DOMObserverErrors.EVENTS}: events array cannot be empty`))
@@ -161,7 +171,7 @@ class DOMObserver {
 				)
 			}
 
-			this._observe(target, callback, { events, attributeFilter })
+			this._observe(target, callback, { events, attributeFilter, root })
 		}).finally(() => {
 			this.clear()
 		})
@@ -203,6 +213,7 @@ class DOMObserver {
 			signal = undefined,
 			once = false,
 			debounce = 0,
+			root = undefined,
 		}: WatchOptions = {}
 	): this {
 		if (!events?.length) {
@@ -252,7 +263,7 @@ class DOMObserver {
 			}
 		}
 
-		this._observe(target, callback, { events, attributeFilter })
+		this._observe(target, callback, { events, attributeFilter, root })
 
 		return this
 	}
@@ -260,7 +271,7 @@ class DOMObserver {
 	private _observe(
 		target: DOMTarget,
 		callback: OnEventCallback,
-		{ events, attributeFilter }: { events: DOMObserverEvent[]; attributeFilter?: string[] }
+		{ events, attributeFilter, root }: { events: DOMObserverEvent[]; attributeFilter?: string[]; root?: DOMTarget }
 	): void {
 		const hasExist = events.includes(DOMObserver.EXIST)
 		const hasAdd = events.includes(DOMObserver.ADD)
@@ -278,6 +289,16 @@ class DOMObserver {
 		if (el && hasExist) {
 			callback(el, DOMObserver.EXIST)
 		}
+
+		let rootEl: Element | null = isElement(root) ? (root as Element) : null
+		if (!rootEl && root) {
+			try {
+				rootEl = document.querySelector(root as string)
+			} catch {
+				throw new Error(`${DOMObserverErrors.TARGET}: "${root}" is not a valid CSS selector`)
+			}
+		}
+		const defaultRoot = rootEl ?? document.documentElement
 
 		this._observer = new MutationObserver((mutations) => {
 			mutations.forEach(({ type, target: targetNode, addedNodes, removedNodes, attributeName, oldValue }) => {
@@ -301,10 +322,10 @@ class DOMObserver {
 			})
 		})
 
-		const observerTarget =
-			hasChange && !hasAdd && !hasRemove && isElement(target) ? target : document.documentElement
+		const isDirectObservation = hasChange && !hasAdd && !hasRemove && isElement(target)
+		const observerTarget = isDirectObservation ? (target as Element) : defaultRoot
 		this._observer.observe(observerTarget, {
-			subtree: observerTarget === document.documentElement,
+			subtree: !isDirectObservation,
 			childList: hasAdd || hasRemove,
 			attributes: hasChange,
 			attributeOldValue: hasChange,

--- a/src/DOMObserver.ts
+++ b/src/DOMObserver.ts
@@ -280,11 +280,11 @@ class DOMObserver {
 		const hasChange = events.includes(DOMObserver.CHANGE)
 
 		const el = resolveDOMTarget(target)
+		const defaultRoot = resolveDOMTarget(root) ?? document.documentElement
+
 		if (el && hasExist) {
 			callback(el, DOMObserver.EXIST)
 		}
-
-		const defaultRoot = resolveDOMTarget(root) ?? document.documentElement
 
 		this._observer = new MutationObserver((mutations) => {
 			mutations.forEach(({ type, target: targetNode, addedNodes, removedNodes, attributeName, oldValue }) => {

--- a/src/DOMObserver.ts
+++ b/src/DOMObserver.ts
@@ -308,7 +308,7 @@ class DOMObserver {
 			})
 		})
 
-		const isDirectObservation = hasChange && !hasAdd && !hasRemove && isElement(target)
+		const isDirectObservation = hasChange && !hasAdd && !hasRemove && isElement(target) && !root
 		const observerTarget = isDirectObservation ? target : defaultRoot
 		this._observer.observe(observerTarget, {
 			subtree: !isDirectObservation,

--- a/src/DOMObserver.ts
+++ b/src/DOMObserver.ts
@@ -1,5 +1,6 @@
 import { DOMObserverErrors } from './DOMObserverErrors'
 import isElement from './utils/isElement'
+import resolveDOMTarget from './utils/resolveDOMTarget'
 
 /** A CSS selector string or a direct DOM Element reference used to identify the observed target. */
 export type DOMTarget = Element | string
@@ -278,27 +279,12 @@ class DOMObserver {
 		const hasRemove = events.includes(DOMObserver.REMOVE)
 		const hasChange = events.includes(DOMObserver.CHANGE)
 
-		let el: Element | null = isElement(target) ? target : null
-		if (!el) {
-			try {
-				el = document.querySelector(target as string)
-			} catch {
-				throw new Error(`${DOMObserverErrors.TARGET}: "${target}" is not a valid CSS selector`)
-			}
-		}
+		const el = resolveDOMTarget(target)
 		if (el && hasExist) {
 			callback(el, DOMObserver.EXIST)
 		}
 
-		let rootEl: Element | null = isElement(root) ? (root as Element) : null
-		if (!rootEl && root) {
-			try {
-				rootEl = document.querySelector(root as string)
-			} catch {
-				throw new Error(`${DOMObserverErrors.TARGET}: "${root}" is not a valid CSS selector`)
-			}
-		}
-		const defaultRoot = rootEl ?? document.documentElement
+		const defaultRoot = resolveDOMTarget(root) ?? document.documentElement
 
 		this._observer = new MutationObserver((mutations) => {
 			mutations.forEach(({ type, target: targetNode, addedNodes, removedNodes, attributeName, oldValue }) => {
@@ -323,7 +309,7 @@ class DOMObserver {
 		})
 
 		const isDirectObservation = hasChange && !hasAdd && !hasRemove && isElement(target)
-		const observerTarget = isDirectObservation ? (target as Element) : defaultRoot
+		const observerTarget = isDirectObservation ? target : defaultRoot
 		this._observer.observe(observerTarget, {
 			subtree: !isDirectObservation,
 			childList: hasAdd || hasRemove,

--- a/src/__tests__/DOMObserver.test.ts
+++ b/src/__tests__/DOMObserver.test.ts
@@ -287,6 +287,24 @@ describe('DOMObserver', () => {
 				expect(() => instance.watch('#foo', onEvent, { root: '##invalid' })).toThrow(DOMObserverErrors.TARGET)
 			})
 
+			it('Respects root when observing CHANGE on an Element reference', async () => {
+				const root = document.createElement('div')
+				document.body.appendChild(root)
+				const el = document.createElement('div')
+				root.appendChild(el)
+				const outside = document.createElement('div')
+				document.body.appendChild(outside)
+				instance.watch(el, onEvent, { events: [DOMObserver.CHANGE], root })
+				outside.setAttribute('data-x', '1')
+				await _sleep()
+				expect(onEvent).not.toHaveBeenCalled()
+				el.setAttribute('data-x', '1')
+				await _sleep()
+				expect(onEvent).toHaveBeenCalledOnce()
+				outside.remove()
+				root.remove()
+			})
+
 			it('Throws when events array is empty', () => {
 				expect(() => instance.watch('#foo', onEvent, { events: [] })).toThrow(DOMObserverErrors.EVENTS)
 			})

--- a/src/__tests__/DOMObserver.test.ts
+++ b/src/__tests__/DOMObserver.test.ts
@@ -90,6 +90,10 @@ describe('DOMObserver', () => {
 					await expect(instance.wait('##invalid')).rejects.toThrow(DOMObserverErrors.TARGET)
 				})
 
+				it('Rejects with [TARGET] error when root selector is invalid', async () => {
+					await expect(instance.wait('#foo', { root: '##invalid' })).rejects.toThrow(DOMObserverErrors.TARGET)
+				})
+
 				it('Rejects immediately when signal is already aborted', async () => {
 					const controller = new AbortController()
 					controller.abort()

--- a/src/__tests__/DOMObserver.test.ts
+++ b/src/__tests__/DOMObserver.test.ts
@@ -119,6 +119,33 @@ describe('DOMObserver', () => {
 					await _sleep(150)
 					expect(instance.isObserving).toBe(true)
 				})
+
+				it('Resolves when target is added within the root element', async () => {
+					const root = document.createElement('div')
+					document.body.appendChild(root)
+					setTimeout(() => {
+						const child = document.createElement('div')
+						child.id = 'scoped'
+						root.appendChild(child)
+					}, 50)
+					const { node } = await instance.wait('#scoped', { events: [DOMObserver.ADD], root })
+					expect(node.id).toBe('scoped')
+					root.remove()
+				})
+
+				it('Resolves when target is added within the root CSS selector', async () => {
+					const root = document.createElement('div')
+					root.id = 'root-scope'
+					document.body.appendChild(root)
+					setTimeout(() => {
+						const child = document.createElement('div')
+						child.id = 'scoped2'
+						root.appendChild(child)
+					}, 50)
+					const { node } = await instance.wait('#scoped2', { events: [DOMObserver.ADD], root: '#root-scope' })
+					expect(node.id).toBe('scoped2')
+					root.remove()
+				})
 			})
 
 			describe('Element creation and mounting are delayed', () => {
@@ -212,6 +239,48 @@ describe('DOMObserver', () => {
 					attributeName: 'data-watched',
 					oldValue: null,
 				})
+			})
+
+			it('Only fires for mutations within the root element', async () => {
+				const root = document.createElement('div')
+				document.body.appendChild(root)
+				const inside = document.createElement('div')
+				inside.id = 'inside'
+				instance.watch('#inside', onEvent, { events: [DOMObserver.ADD], root })
+				root.appendChild(inside)
+				await _sleep()
+				expect(onEvent).toHaveBeenCalledOnce()
+				root.remove()
+			})
+
+			it('Does not fire for mutations outside the root element', async () => {
+				const root = document.createElement('div')
+				document.body.appendChild(root)
+				const outside = document.createElement('div')
+				outside.id = 'outside'
+				instance.watch('#outside', onEvent, { events: [DOMObserver.ADD], root })
+				document.body.appendChild(outside)
+				await _sleep()
+				expect(onEvent).not.toHaveBeenCalled()
+				outside.remove()
+				root.remove()
+			})
+
+			it('Accepts a CSS selector as root', async () => {
+				const root = document.createElement('div')
+				root.id = 'watch-root'
+				document.body.appendChild(root)
+				const inside = document.createElement('div')
+				inside.id = 'inside2'
+				instance.watch('#inside2', onEvent, { events: [DOMObserver.ADD], root: '#watch-root' })
+				root.appendChild(inside)
+				await _sleep()
+				expect(onEvent).toHaveBeenCalledOnce()
+				root.remove()
+			})
+
+			it('Throws with [TARGET] error when root selector is invalid', () => {
+				expect(() => instance.watch('#foo', onEvent, { root: '##invalid' })).toThrow(DOMObserverErrors.TARGET)
 			})
 
 			it('Throws when events array is empty', () => {

--- a/src/utils/resolveDOMTarget.ts
+++ b/src/utils/resolveDOMTarget.ts
@@ -1,0 +1,15 @@
+import { DOMObserverErrors } from '../DOMObserverErrors'
+import type { DOMTarget } from '../DOMObserver'
+import isElement from './isElement'
+
+const resolveDOMTarget = (target: DOMTarget | undefined): Element | null => {
+	if (!target) return null
+	if (isElement(target)) return target as Element
+	try {
+		return document.querySelector(target as string)
+	} catch {
+		throw new Error(`${DOMObserverErrors.TARGET}: "${target}" is not a valid CSS selector`)
+	}
+}
+
+export default resolveDOMTarget


### PR DESCRIPTION
## Summary

Adds a `root?: DOMTarget` option to both `wait()` and `watch()` that restricts the `MutationObserver` to a specific DOM subtree instead of always watching `document.documentElement`. Like `target`, `root` accepts either a direct `Element` reference or a CSS selector string. When `root` resolves to `null` (element not yet in DOM), `document.documentElement` is used as fallback.

As a bonus, the `observerTarget`/`subtree` logic in `_observe()` was refactored to use a cleaner `isDirectObservation` flag, replacing the previous `observerTarget === document.documentElement` check.

## Changes

- `src/DOMObserver.ts` — `WaitOptions` and `WatchOptions`: new `root?: DOMTarget` field with JSDoc; `wait()` and `watch()`: destructure and forward `root` to `_observe()`; `_observe()`: resolve `root` like `target` (Element or querySelector), fall back to `document.documentElement`; refactored `isDirectObservation` flag for `observerTarget`/`subtree`
- `src/__tests__/DOMObserver.test.ts` — 6 new tests: `wait()` with Element root, `wait()` with selector root, `watch()` fires inside root, `watch()` ignores outside root, `watch()` with selector root, invalid root selector throws `[TARGET]`
- `README.md` — `root` row added to both `watch()` and `wait()` options tables

## Test plan

- [x] `yarn test:ci` passes (48 tests, 100% coverage)
- [x] `yarn build` succeeds — `root` appears in the generated `.d.ts`

Closes #46