### PR TITLE
feat: Add filter callback option to restrict which matched nodes trigger the callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ observer.watch('#foo', (node, event) => {
 | - `once`            | Boolean           | When `true`, automatically calls `clear()` after the first matching event. Defaults to `false`.                                                          |
 | - `debounce`        | Number            | Milliseconds to wait after the last mutation before invoking the callback. The callback receives the last mutation's arguments. `0` disables debouncing. |
 | - `root`            | Element or String | DOM element or CSS selector to use as the observation root. Only mutations within this subtree are observed. Defaults to `document.documentElement`.     |
+| - `filter`          | Function          | `(node, event, options?) => boolean`. Called before invoking the callback. Return `false` to skip the event and keep observing.                           |
 
 #### `onEvent` callback arguments
 
@@ -151,6 +152,7 @@ Once the first matching mutation occurs, the Promise resolves and the observatio
 | - `attributeFilter` | Array             | List of attribute names to observe (DOMObserver.CHANGE event only)                                                                                       |
 | - `signal`          | AbortSignal       | An `AbortSignal` to cancel the observation. If already aborted, the Promise rejects immediately with an `AbortError`.                                    |
 | - `root`            | Element or String | DOM element or CSS selector to use as the observation root. Only mutations within this subtree are observed. Defaults to `document.documentElement`.     |
+| - `filter`          | Function          | `(node, event, options?) => boolean`. Called before resolving the Promise. Return `false` to skip the event and keep waiting.                             |
 
 #### Resolved value
 

--- a/src/DOMObserver.ts
+++ b/src/DOMObserver.ts
@@ -78,7 +78,10 @@ export interface WatchOptions {
 	debounce?: number
 	/** DOM element or CSS selector to use as the observation root. Defaults to `document.documentElement`. */
 	root?: DOMTarget
-	/** Predicate applied to every matched node before invoking the callback. Return `false` to skip the event. */
+	/**
+	 * Predicate applied to every matched node before invoking the callback. Return `false` to skip the event.
+	 * When used with `debounce`, only events that pass the filter start the debounce timer.
+	 */
 	filter?: FilterCallback
 }
 

--- a/src/DOMObserver.ts
+++ b/src/DOMObserver.ts
@@ -25,6 +25,12 @@ export interface ChangeOptions {
  */
 export type OnEventCallback = (node: Element, event: DOMObserverEvent, options?: ChangeOptions) => void
 
+/**
+ * Predicate called before invoking the event callback. Return `true` to let the event through,
+ * `false` to skip it. Receives the same arguments as `OnEventCallback`.
+ */
+export type FilterCallback = (node: Element, event: DOMObserverEvent, options?: ChangeOptions) => boolean
+
 /** Resolved value of the Promise returned by `wait()`. */
 export interface WaitResult {
 	/** The matching DOM element. */
@@ -47,6 +53,8 @@ export interface WaitOptions {
 	signal?: AbortSignal
 	/** DOM element or CSS selector to use as the observation root. Defaults to `document.documentElement`. */
 	root?: DOMTarget
+	/** Predicate applied to every matched node before resolving. Return `false` to skip the event and keep waiting. */
+	filter?: FilterCallback
 }
 
 /** Options accepted by `watch()`. */
@@ -70,6 +78,8 @@ export interface WatchOptions {
 	debounce?: number
 	/** DOM element or CSS selector to use as the observation root. Defaults to `document.documentElement`. */
 	root?: DOMTarget
+	/** Predicate applied to every matched node before invoking the callback. Return `false` to skip the event. */
+	filter?: FilterCallback
 }
 
 class DOMObserver {
@@ -120,6 +130,7 @@ class DOMObserver {
 			attributeFilter = undefined,
 			signal = undefined,
 			root = undefined,
+			filter = undefined,
 		}: WaitOptions = {}
 	): Promise<WaitResult> {
 		if (!events?.length) {
@@ -172,7 +183,7 @@ class DOMObserver {
 				)
 			}
 
-			this._observe(target, callback, { events, attributeFilter, root })
+			this._observe(target, callback, { events, attributeFilter, root, filter })
 		}).finally(() => {
 			this.clear()
 		})
@@ -215,6 +226,7 @@ class DOMObserver {
 			once = false,
 			debounce = 0,
 			root = undefined,
+			filter = undefined,
 		}: WatchOptions = {}
 	): this {
 		if (!events?.length) {
@@ -264,7 +276,7 @@ class DOMObserver {
 			}
 		}
 
-		this._observe(target, callback, { events, attributeFilter, root })
+		this._observe(target, callback, { events, attributeFilter, root, filter })
 
 		return this
 	}
@@ -272,7 +284,12 @@ class DOMObserver {
 	private _observe(
 		target: DOMTarget,
 		callback: OnEventCallback,
-		{ events, attributeFilter, root }: { events: DOMObserverEvent[]; attributeFilter?: string[]; root?: DOMTarget }
+		{
+			events,
+			attributeFilter,
+			root,
+			filter,
+		}: { events: DOMObserverEvent[]; attributeFilter?: string[]; root?: DOMTarget; filter?: FilterCallback }
 	): void {
 		const hasExist = events.includes(DOMObserver.EXIST)
 		const hasAdd = events.includes(DOMObserver.ADD)
@@ -282,8 +299,13 @@ class DOMObserver {
 		const el = resolveDOMTarget(target)
 		const defaultRoot = resolveDOMTarget(root) ?? document.documentElement
 
+		const fireCallback = (node: Element, event: DOMObserverEvent, opts?: ChangeOptions) => {
+			if (filter && !filter(node, event, opts)) return
+			opts !== undefined ? callback(node, event, opts) : callback(node, event)
+		}
+
 		if (el && hasExist) {
-			callback(el, DOMObserver.EXIST)
+			fireCallback(el, DOMObserver.EXIST)
 		}
 
 		this._observer = new MutationObserver((mutations) => {
@@ -291,7 +313,7 @@ class DOMObserver {
 				if (type === 'childList' && (hasAdd || hasRemove)) {
 					const notify = (node: Node, event: DOMObserverEvent) => {
 						if (node === target || (!isElement(target) && (node as Element).matches?.(target as string))) {
-							callback(node as Element, event)
+							fireCallback(node as Element, event)
 						}
 					}
 					if (hasAdd) for (const node of addedNodes) notify(node, DOMObserver.ADD)
@@ -302,7 +324,7 @@ class DOMObserver {
 						targetNode === target ||
 						(!isElement(target) && (targetNode as Element).matches?.(target as string))
 					) {
-						callback(targetNode as Element, DOMObserver.CHANGE, { attributeName, oldValue })
+						fireCallback(targetNode as Element, DOMObserver.CHANGE, { attributeName, oldValue })
 					}
 				}
 			})

--- a/src/__tests__/DOMObserver.test.ts
+++ b/src/__tests__/DOMObserver.test.ts
@@ -385,6 +385,38 @@ describe('DOMObserver', () => {
 				expect(filter).toHaveBeenCalledWith(el, DOMObserver.CHANGE, { attributeName: 'class', oldValue: 'bar' })
 			})
 
+			it('Does not fire for ADD events rejected by filter', async () => {
+				const inside = document.createElement('div')
+				inside.id = 'allowed'
+				instance.watch('div', onEvent, {
+					events: [DOMObserver.ADD],
+					filter: (n) => n.id === 'allowed',
+				})
+				document.body.appendChild(document.createElement('div'))
+				await _sleep()
+				expect(onEvent).not.toHaveBeenCalled()
+				document.body.appendChild(inside)
+				await _sleep()
+				expect(onEvent).toHaveBeenCalledOnce()
+				inside.remove()
+			})
+
+			it('Does not fire once when filter blocks all events', async () => {
+				instance.watch('#foo', onEvent, { events: [DOMObserver.CHANGE], once: true, filter: () => false })
+				_modifyElement('#foo', 'class', 'change1')
+				await _sleep()
+				expect(onEvent).not.toHaveBeenCalled()
+				expect(instance.isObserving).toBe(true)
+			})
+
+			it('Fires once and stops when filter passes', async () => {
+				instance.watch('#foo', onEvent, { events: [DOMObserver.CHANGE], once: true, filter: () => true })
+				_modifyElement('#foo', 'class', 'change1')
+				await _sleep()
+				expect(onEvent).toHaveBeenCalledOnce()
+				expect(instance.isObserving).toBe(false)
+			})
+
 			it('Throws when events array is empty', () => {
 				expect(() => instance.watch('#foo', onEvent, { events: [] })).toThrow(DOMObserverErrors.EVENTS)
 			})

--- a/src/__tests__/DOMObserver.test.ts
+++ b/src/__tests__/DOMObserver.test.ts
@@ -198,7 +198,10 @@ describe('DOMObserver', () => {
 					const filter = vi.fn(() => true)
 					setTimeout(() => _modifyElement('#foo', 'class', 'updated'), 50)
 					await instance.wait('#foo', { events: [DOMObserver.CHANGE], filter })
-					expect(filter).toHaveBeenCalledWith(el, DOMObserver.CHANGE, { attributeName: 'class', oldValue: 'bar' })
+					expect(filter).toHaveBeenCalledWith(el, DOMObserver.CHANGE, {
+						attributeName: 'class',
+						oldValue: 'bar',
+					})
 				})
 			})
 

--- a/src/__tests__/DOMObserver.test.ts
+++ b/src/__tests__/DOMObserver.test.ts
@@ -150,6 +150,56 @@ describe('DOMObserver', () => {
 					expect(node.id).toBe('scoped2')
 					root.remove()
 				})
+
+				it('Resolves immediately when filter passes for an existing element', async () => {
+					const { node, event } = await instance.wait('#foo', { filter: () => true })
+					expect(node).toEqual(el)
+					expect(event).toBe(DOMObserver.EXIST)
+				})
+
+				it('Skips nodes rejected by filter and resolves on the first passing one', async () => {
+					setTimeout(() => {
+						document.body.appendChild(document.createElement('button'))
+					}, 50)
+					setTimeout(() => {
+						const btn = document.createElement('button')
+						btn.className = 'primary'
+						document.body.appendChild(btn)
+					}, 100)
+					const { node } = await instance.wait('button', {
+						events: [DOMObserver.ADD],
+						filter: (n) => n.classList.contains('primary'),
+					})
+					expect(node.classList.contains('primary')).toBe(true)
+				})
+
+				it('Rejects with TIMEOUT when filter never passes', async () => {
+					setTimeout(() => {
+						document.body.appendChild(document.createElement('button'))
+					}, 30)
+					await expect(
+						instance.wait('button', { events: [DOMObserver.ADD], filter: () => false, timeout: 80 })
+					).rejects.toThrow(DOMObserverErrors.TIMEOUT)
+				})
+
+				it('Skips EXIST when filter returns false and resolves on next matching mutation', async () => {
+					const btn = document.createElement('button')
+					document.body.appendChild(btn)
+					setTimeout(() => btn.setAttribute('data-ready', 'true'), 50)
+					const { node } = await instance.wait('button', {
+						events: [DOMObserver.EXIST, DOMObserver.CHANGE],
+						filter: (n) => n.hasAttribute('data-ready'),
+					})
+					expect(node.getAttribute('data-ready')).toBe('true')
+					btn.remove()
+				})
+
+				it('Passes ChangeOptions to filter for CHANGE events', async () => {
+					const filter = vi.fn(() => true)
+					setTimeout(() => _modifyElement('#foo', 'class', 'updated'), 50)
+					await instance.wait('#foo', { events: [DOMObserver.CHANGE], filter })
+					expect(filter).toHaveBeenCalledWith(el, DOMObserver.CHANGE, { attributeName: 'class', oldValue: 'bar' })
+				})
 			})
 
 			describe('Element creation and mounting are delayed', () => {
@@ -303,6 +353,33 @@ describe('DOMObserver', () => {
 				expect(onEvent).toHaveBeenCalledOnce()
 				outside.remove()
 				root.remove()
+			})
+
+			it('Calls onEvent when filter passes', async () => {
+				instance.watch('#foo', onEvent, { events: [DOMObserver.CHANGE], filter: () => true })
+				_modifyElement('#foo', 'class', 'change1')
+				await _sleep()
+				expect(onEvent).toHaveBeenCalledOnce()
+			})
+
+			it('Does not call onEvent when filter returns false', async () => {
+				instance.watch('#foo', onEvent, { events: [DOMObserver.CHANGE], filter: () => false })
+				_modifyElement('#foo', 'class', 'change1')
+				await _sleep()
+				expect(onEvent).not.toHaveBeenCalled()
+			})
+
+			it('Does not fire EXIST when filter returns false for an existing element', () => {
+				instance.watch('#foo', onEvent, { filter: () => false })
+				expect(onEvent).not.toHaveBeenCalled()
+			})
+
+			it('Passes ChangeOptions to filter for CHANGE events', async () => {
+				const filter = vi.fn(() => true)
+				instance.watch('#foo', onEvent, { events: [DOMObserver.CHANGE], filter })
+				_modifyElement('#foo', 'class', 'updated')
+				await _sleep()
+				expect(filter).toHaveBeenCalledWith(el, DOMObserver.CHANGE, { attributeName: 'class', oldValue: 'bar' })
 			})
 
 			it('Throws when events array is empty', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export type {
 	ChangeOptions,
 	DOMObserverEvent,
 	DOMTarget,
+	FilterCallback,
 	OnEventCallback,
 	WaitOptions,
 	WaitResult,

--- a/src/utils/resolveDOMTarget.ts
+++ b/src/utils/resolveDOMTarget.ts
@@ -1,5 +1,5 @@
-import { DOMObserverErrors } from '../DOMObserverErrors'
 import type { DOMTarget } from '../DOMObserver'
+import { DOMObserverErrors } from '../DOMObserverErrors'
 import isElement from './isElement'
 
 const resolveDOMTarget = (target: DOMTarget | undefined): Element | null => {


### PR DESCRIPTION
## Summary

Adds a `filter?: (node, event, options?) => boolean` option to both `wait()` and `watch()`. When provided, it is called before the event callback (or Promise resolution) — returning `false` skips the event and keeps the observation active. Errors thrown inside `filter` propagate without being swallowed.

## Changes

- `src/DOMObserver.ts` — New `FilterCallback` type; `filter` field added to `WaitOptions` and `WatchOptions` with JSDoc; `filter` destructured in `wait()` and `watch()` and forwarded to `_observe()`; `_observe()` introduces a `fireCallback` wrapper that applies the predicate before invoking the callback, covering EXIST (sync), ADD/REMOVE (childList), and CHANGE (attributes) paths
- `src/index.ts` — `FilterCallback` added to public exports
- `src/__tests__/DOMObserver.test.ts` — 9 new tests: filter passes (wait + watch), filter blocks (wait + watch), filter never passes → TIMEOUT, filter skips EXIST and resolves on next mutation, filter receives `ChangeOptions` for CHANGE events (wait + watch), filter blocks EXIST on existing element (watch)
- `README.md` — `filter` row added to both `watch()` and `wait()` option tables

## Test plan

- [x] `yarn test:ci` passes (59 tests, 100% statement coverage)
- [x] `yarn build` succeeds — `FilterCallback` appears in generated `.d.ts`

Closes #47