### PR TITLE
feat: Support multiple targets in wait()

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,13 +139,22 @@ switch (event) {
 }
 ```
 
+Pass an **array of targets** to resolve as soon as any one of them fires a matching event. The resolved value includes a `target` field identifying which entry won:
+
+```javascript
+const { node, target } = await observer.wait(['#success', '#error'], {
+	events: [DOMObserver.ADD],
+})
+console.log(`Matched: ${target}`)
+```
+
 Once the first matching mutation occurs, the Promise resolves and the observation stops automatically. If a `timeout` is set and elapses before any matching mutation, the Promise rejects with a `[TIMEOUT]` error.
 
 #### `wait` method arguments
 
-| Props               | Type              | Description                                                                                                                                              |
-| ------------------- | ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `target`            | Element or String | DOM element or selector of the DOM element to observe. See [querySelector spec](https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector) |
+| Props               | Type                       | Description                                                                                                                                              |
+| ------------------- | -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `target`            | Element, String, or Array  | DOM element, selector, or array of either. When an array is passed, resolves on the first match across all entries.                                      |
 | `options`           | Object            | Options object:                                                                                                                                          |
 | - `events`          | Array             | List of [events](#events) to observe (All events are observed by default)                                                                                |
 | - `timeout`         | Number            | Duration (in ms) before rejecting the Promise with a `[TIMEOUT]` error. `0` disables the timeout.                                                       |
@@ -156,13 +165,14 @@ Once the first matching mutation occurs, the Promise resolves and the observatio
 
 #### Resolved value
 
-| Props             | Type           | Description                                                                 |
-| ----------------- | -------------- | --------------------------------------------------------------------------- |
-| `node`            | Element        | The matching DOM element                                                    |
-| `event`           | String         | The event type that caused the Promise to settle                            |
-| `options`         | Object         | Present only for `CHANGE` events:                                           |
-| - `attributeName` | String         | Name of the attribute that changed                                          |
-| - `oldValue`      | String or null | Value of the attribute before the mutation                                  |
+| Props             | Type                  | Description                                                                                          |
+| ----------------- | --------------------- | ---------------------------------------------------------------------------------------------------- |
+| `node`            | Element               | The matching DOM element                                                                             |
+| `event`           | String                | The event type that caused the Promise to settle                                                     |
+| `target`          | Element, String, or undefined | The entry from the targets array that matched. `undefined` when a single target was passed. |
+| `options`         | Object                | Present only for `CHANGE` events:                                                                    |
+| - `attributeName` | String                | Name of the attribute that changed                                                                   |
+| - `oldValue`      | String or null        | Value of the attribute before the mutation                                                           |
 
 #### Events
 

--- a/src/DOMObserver.ts
+++ b/src/DOMObserver.ts
@@ -201,14 +201,9 @@ class DOMObserver {
 				)
 			}
 
-			this._observe(
-				target,
-				callback,
-				{ events, attributeFilter, root, filter },
-				(t) => {
-					matchedTarget = t
-				}
-			)
+			this._observe(target, callback, { events, attributeFilter, root, filter }, (t) => {
+				matchedTarget = t
+			})
 		}).finally(() => {
 			this.clear()
 		})
@@ -332,10 +327,12 @@ class DOMObserver {
 		}
 
 		if (hasExist) {
-			const existMatch = resolvedTargets.find(({ el }) => el !== null)
-			if (existMatch) {
-				onMatch?.(existMatch.target)
-				fireCallback(existMatch.el!, DOMObserver.EXIST)
+			for (const { target: t, el } of resolvedTargets) {
+				if (el) {
+					onMatch?.(t)
+					fireCallback(el, DOMObserver.EXIST)
+					break
+				}
 			}
 		}
 

--- a/src/DOMObserver.ts
+++ b/src/DOMObserver.ts
@@ -184,6 +184,8 @@ class DOMObserver {
 
 			this._pendingReject = cancel
 
+			// onMatch always fires synchronously before fireCallback in _observe, so matchedTarget
+			// is guaranteed to be set before callback runs.
 			const callback: OnEventCallback = (node, event, options) => {
 				const result: WaitResult = options ? { node, event, options } : { node, event }
 				if (isMulti) result.target = matchedTarget

--- a/src/DOMObserver.ts
+++ b/src/DOMObserver.ts
@@ -200,7 +200,9 @@ class DOMObserver {
 					() =>
 						cancel(
 							new Error(
-								`${DOMObserverErrors.TIMEOUT}: Element ${targetLabel} cannot be found after ${timeout}ms`
+								isMulti
+										? `${DOMObserverErrors.TIMEOUT}: None of ${targetLabel} could be found after ${timeout}ms`
+										: `${DOMObserverErrors.TIMEOUT}: Element ${targetLabel} cannot be found after ${timeout}ms`
 							)
 						),
 					timeout

--- a/src/DOMObserver.ts
+++ b/src/DOMObserver.ts
@@ -157,7 +157,13 @@ class DOMObserver {
 		this.clear()
 
 		const isMulti = Array.isArray(target)
-		const targetLabel = isMulti ? (target as DOMTarget[]).join(', ') : target
+		const formatTarget = (t: DOMTarget): string =>
+			isElement(t)
+				? `<${(t as Element).tagName.toLowerCase()}${(t as Element).id ? `#${(t as Element).id}` : ''}>`
+				: String(t)
+		const targetLabel = isMulti
+			? `[${(target as DOMTarget[]).map(formatTarget).join(', ')}]`
+			: formatTarget(target as DOMTarget)
 
 		return new Promise<WaitResult>((resolve, reject) => {
 			let onAbort: (() => void) | null = null

--- a/src/DOMObserver.ts
+++ b/src/DOMObserver.ts
@@ -201,8 +201,8 @@ class DOMObserver {
 						cancel(
 							new Error(
 								isMulti
-										? `${DOMObserverErrors.TIMEOUT}: None of ${targetLabel} could be found after ${timeout}ms`
-										: `${DOMObserverErrors.TIMEOUT}: Element ${targetLabel} cannot be found after ${timeout}ms`
+									? `${DOMObserverErrors.TIMEOUT}: None of ${targetLabel} could be found after ${timeout}ms`
+									: `${DOMObserverErrors.TIMEOUT}: Element ${targetLabel} cannot be found after ${timeout}ms`
 							)
 						),
 					timeout
@@ -334,6 +334,19 @@ class DOMObserver {
 			opts !== undefined ? callback(node, event, opts) : callback(node, event)
 		}
 
+		const nodeMatchesTarget = (node: Node, t: DOMTarget): boolean =>
+			node === t || (!isElement(t) && (node as Element).matches?.(t as string))
+
+		const notify = (node: Node, event: DOMObserverEvent) => {
+			for (const { target: t } of resolvedTargets) {
+				if (nodeMatchesTarget(node, t)) {
+					onMatch?.(t)
+					fireCallback(node as Element, event)
+					return
+				}
+			}
+		}
+
 		if (hasExist) {
 			for (const { target: t, el } of resolvedTargets) {
 				if (el) {
@@ -347,21 +360,12 @@ class DOMObserver {
 		this._observer = new MutationObserver((mutations) => {
 			mutations.forEach(({ type, target: targetNode, addedNodes, removedNodes, attributeName, oldValue }) => {
 				if (type === 'childList' && (hasAdd || hasRemove)) {
-					const notify = (node: Node, event: DOMObserverEvent) => {
-						for (const { target: t } of resolvedTargets) {
-							if (node === t || (!isElement(t) && (node as Element).matches?.(t as string))) {
-								onMatch?.(t)
-								fireCallback(node as Element, event)
-								return
-							}
-						}
-					}
 					if (hasAdd) for (const node of addedNodes) notify(node, DOMObserver.ADD)
 					if (hasRemove) for (const node of removedNodes) notify(node, DOMObserver.REMOVE)
 				}
 				if (type === 'attributes' && hasChange) {
 					for (const { target: t } of resolvedTargets) {
-						if (targetNode === t || (!isElement(t) && (targetNode as Element).matches?.(t as string))) {
+						if (nodeMatchesTarget(targetNode, t)) {
 							onMatch?.(t)
 							fireCallback(targetNode as Element, DOMObserver.CHANGE, { attributeName, oldValue })
 							break

--- a/src/DOMObserver.ts
+++ b/src/DOMObserver.ts
@@ -39,6 +39,8 @@ export interface WaitResult {
 	event: DOMObserverEvent
 	/** Additional mutation metadata, present only for `CHANGE` events. */
 	options?: ChangeOptions
+	/** The target entry that triggered the match. Only populated when `wait()` was called with an array of targets. */
+	target?: DOMTarget
 }
 
 /** Options accepted by `wait()`. */
@@ -119,14 +121,20 @@ class DOMObserver {
 	 * Calling `wait()` while a previous call is still pending rejects the previous Promise with `[ABORT]`
 	 * and starts a fresh observation.
 	 *
-	 * @param target - CSS selector or Element to observe.
+	 * When an array of targets is passed, the Promise resolves as soon as any one of them fires a
+	 * matching event. The resolved `WaitResult.target` identifies which entry won. For EXIST checks,
+	 * the first target found in the DOM wins.
+	 *
+	 * @param target - CSS selector, Element, or array of either to observe.
 	 * @param options - Observation options.
 	 * @returns A Promise that resolves with the matching node, event type, and optional change metadata.
 	 * @throws `[EVENTS]` when the `events` array is empty.
-	 * @throws `[TARGET]` when `target` is a string that is not a valid CSS selector.
+	 * @throws `[TARGET]` when any target string is not a valid CSS selector.
 	 */
+	wait(target: DOMTarget, options?: WaitOptions): Promise<WaitResult>
+	wait(targets: DOMTarget[], options?: WaitOptions): Promise<WaitResult>
 	wait(
-		target: DOMTarget,
+		target: DOMTarget | DOMTarget[],
 		{
 			events = DOMObserver.EVENTS,
 			timeout = 0,
@@ -148,8 +156,12 @@ class DOMObserver {
 		this._pendingReject = null
 		this.clear()
 
+		const isMulti = Array.isArray(target)
+		const targetLabel = isMulti ? (target as DOMTarget[]).join(', ') : target
+
 		return new Promise<WaitResult>((resolve, reject) => {
 			let onAbort: (() => void) | null = null
+			let matchedTarget: DOMTarget | undefined
 
 			const cleanup = () => {
 				if (onAbort) signal?.removeEventListener('abort', onAbort)
@@ -166,8 +178,11 @@ class DOMObserver {
 
 			this._pendingReject = cancel
 
-			const callback: OnEventCallback = (node, event, options) =>
-				settle(options ? { node, event, options } : { node, event })
+			const callback: OnEventCallback = (node, event, options) => {
+				const result: WaitResult = options ? { node, event, options } : { node, event }
+				if (isMulti) result.target = matchedTarget
+				settle(result)
+			}
 
 			if (signal) {
 				onAbort = () => cancel(signal.reason ?? new DOMException('Aborted', 'AbortError'))
@@ -179,14 +194,21 @@ class DOMObserver {
 					() =>
 						cancel(
 							new Error(
-								`${DOMObserverErrors.TIMEOUT}: Element ${target} cannot be found after ${timeout}ms`
+								`${DOMObserverErrors.TIMEOUT}: Element ${targetLabel} cannot be found after ${timeout}ms`
 							)
 						),
 					timeout
 				)
 			}
 
-			this._observe(target, callback, { events, attributeFilter, root, filter })
+			this._observe(
+				target,
+				callback,
+				{ events, attributeFilter, root, filter },
+				(t) => {
+					matchedTarget = t
+				}
+			)
 		}).finally(() => {
 			this.clear()
 		})
@@ -285,21 +307,23 @@ class DOMObserver {
 	}
 
 	private _observe(
-		target: DOMTarget,
+		target: DOMTarget | DOMTarget[],
 		callback: OnEventCallback,
 		{
 			events,
 			attributeFilter,
 			root,
 			filter,
-		}: { events: DOMObserverEvent[]; attributeFilter?: string[]; root?: DOMTarget; filter?: FilterCallback }
+		}: { events: DOMObserverEvent[]; attributeFilter?: string[]; root?: DOMTarget; filter?: FilterCallback },
+		onMatch?: (matchedTarget: DOMTarget) => void
 	): void {
 		const hasExist = events.includes(DOMObserver.EXIST)
 		const hasAdd = events.includes(DOMObserver.ADD)
 		const hasRemove = events.includes(DOMObserver.REMOVE)
 		const hasChange = events.includes(DOMObserver.CHANGE)
 
-		const el = resolveDOMTarget(target)
+		const targets = Array.isArray(target) ? target : [target]
+		const resolvedTargets = targets.map((t) => ({ target: t, el: resolveDOMTarget(t) }))
 		const defaultRoot = resolveDOMTarget(root) ?? document.documentElement
 
 		const fireCallback = (node: Element, event: DOMObserverEvent, opts?: ChangeOptions) => {
@@ -307,34 +331,44 @@ class DOMObserver {
 			opts !== undefined ? callback(node, event, opts) : callback(node, event)
 		}
 
-		if (el && hasExist) {
-			fireCallback(el, DOMObserver.EXIST)
+		if (hasExist) {
+			const existMatch = resolvedTargets.find(({ el }) => el !== null)
+			if (existMatch) {
+				onMatch?.(existMatch.target)
+				fireCallback(existMatch.el!, DOMObserver.EXIST)
+			}
 		}
 
 		this._observer = new MutationObserver((mutations) => {
 			mutations.forEach(({ type, target: targetNode, addedNodes, removedNodes, attributeName, oldValue }) => {
 				if (type === 'childList' && (hasAdd || hasRemove)) {
 					const notify = (node: Node, event: DOMObserverEvent) => {
-						if (node === target || (!isElement(target) && (node as Element).matches?.(target as string))) {
-							fireCallback(node as Element, event)
+						for (const { target: t } of resolvedTargets) {
+							if (node === t || (!isElement(t) && (node as Element).matches?.(t as string))) {
+								onMatch?.(t)
+								fireCallback(node as Element, event)
+								return
+							}
 						}
 					}
 					if (hasAdd) for (const node of addedNodes) notify(node, DOMObserver.ADD)
 					if (hasRemove) for (const node of removedNodes) notify(node, DOMObserver.REMOVE)
 				}
 				if (type === 'attributes' && hasChange) {
-					if (
-						targetNode === target ||
-						(!isElement(target) && (targetNode as Element).matches?.(target as string))
-					) {
-						fireCallback(targetNode as Element, DOMObserver.CHANGE, { attributeName, oldValue })
+					for (const { target: t } of resolvedTargets) {
+						if (targetNode === t || (!isElement(t) && (targetNode as Element).matches?.(t as string))) {
+							onMatch?.(t)
+							fireCallback(targetNode as Element, DOMObserver.CHANGE, { attributeName, oldValue })
+							break
+						}
 					}
 				}
 			})
 		})
 
-		const isDirectObservation = hasChange && !hasAdd && !hasRemove && isElement(target) && !root
-		const observerTarget = isDirectObservation ? target : defaultRoot
+		const isDirectObservation =
+			targets.length === 1 && hasChange && !hasAdd && !hasRemove && isElement(targets[0]) && !root
+		const observerTarget = isDirectObservation ? (targets[0] as Element) : defaultRoot
 		this._observer.observe(observerTarget, {
 			subtree: !isDirectObservation,
 			childList: hasAdd || hasRemove,

--- a/src/DOMObserver.ts
+++ b/src/DOMObserver.ts
@@ -157,13 +157,6 @@ class DOMObserver {
 		this.clear()
 
 		const isMulti = Array.isArray(target)
-		const formatTarget = (t: DOMTarget): string =>
-			isElement(t)
-				? `<${(t as Element).tagName.toLowerCase()}${(t as Element).id ? `#${(t as Element).id}` : ''}>`
-				: String(t)
-		const targetLabel = isMulti
-			? `[${(target as DOMTarget[]).map(formatTarget).join(', ')}]`
-			: formatTarget(target as DOMTarget)
 
 		return new Promise<WaitResult>((resolve, reject) => {
 			let onAbort: (() => void) | null = null
@@ -198,6 +191,11 @@ class DOMObserver {
 			}
 
 			if (timeout > 0) {
+				const formatTarget = (t: DOMTarget): string =>
+					isElement(t) ? `<${t.tagName.toLowerCase()}${t.id ? `#${t.id}` : ''}>` : String(t)
+				const targetLabel = isMulti
+					? `[${(target as DOMTarget[]).map(formatTarget).join(', ')}]`
+					: formatTarget(target as DOMTarget)
 				this._timeout = setTimeout(
 					() =>
 						cancel(

--- a/src/__tests__/DOMObserver.test.ts
+++ b/src/__tests__/DOMObserver.test.ts
@@ -287,6 +287,30 @@ describe('DOMObserver', () => {
 				setTimeout(() => controller.abort(), 50)
 				await expect(promise).rejects.toMatchObject({ name: 'AbortError' })
 			})
+
+			it('Respects filter across multi-target ADD events', async () => {
+				let callCount = 0
+				setTimeout(() => {
+					const div = document.createElement('div')
+					div.id = 'filtered-a'
+					document.body.appendChild(div)
+				}, 20)
+				setTimeout(() => {
+					const div = document.createElement('div')
+					div.id = 'filtered-b'
+					document.body.appendChild(div)
+				}, 50)
+				const { node, target } = await instance.wait(['#filtered-a', '#filtered-b'], {
+					events: [DOMObserver.ADD],
+					filter: (node) => {
+						callCount++
+						return node.id === 'filtered-b'
+					},
+				})
+				expect(node.id).toBe('filtered-b')
+				expect(target).toBe('#filtered-b')
+				expect(callCount).toBeGreaterThanOrEqual(2)
+			})
 		})
 	})
 

--- a/src/__tests__/DOMObserver.test.ts
+++ b/src/__tests__/DOMObserver.test.ts
@@ -203,6 +203,11 @@ describe('DOMObserver', () => {
 						oldValue: 'bar',
 					})
 				})
+
+				it('Leaves result.target undefined for a single-target call', async () => {
+					const { target } = await instance.wait('#foo')
+					expect(target).toBeUndefined()
+				})
 			})
 
 			describe('Element creation and mounting are delayed', () => {
@@ -263,11 +268,6 @@ describe('DOMObserver', () => {
 				expect(target).toBe('#second-wins')
 			})
 
-			it('Leaves result.target undefined for a single-target call', async () => {
-				const { target } = await instance.wait('#foo')
-				expect(target).toBeUndefined()
-			})
-
 			it('Rejects with [TARGET] when any target selector is invalid', async () => {
 				await expect(instance.wait(['#foo', '##invalid'])).rejects.toThrow(DOMObserverErrors.TARGET)
 			})
@@ -286,6 +286,27 @@ describe('DOMObserver', () => {
 				})
 				setTimeout(() => controller.abort(), 50)
 				await expect(promise).rejects.toMatchObject({ name: 'AbortError' })
+			})
+
+			it('Resolves on REMOVE for the matching target', async () => {
+				const second = document.createElement('div')
+				second.id = 'removable'
+				document.body.appendChild(second)
+				setTimeout(() => second.remove(), 50)
+				const { node, target } = await instance.wait(['#foo', '#removable'], { events: [DOMObserver.REMOVE] })
+				expect(node.id).toBe('removable')
+				expect(target).toBe('#removable')
+			})
+
+			it('Resolves on CHANGE for the matching target', async () => {
+				const second = document.createElement('div')
+				second.id = 'changeable'
+				document.body.appendChild(second)
+				setTimeout(() => second.setAttribute('data-x', '1'), 50)
+				const { node, target } = await instance.wait(['#foo', '#changeable'], { events: [DOMObserver.CHANGE] })
+				expect(node.id).toBe('changeable')
+				expect(target).toBe('#changeable')
+				second.remove()
 			})
 
 			it('Respects filter across multi-target ADD events', async () => {

--- a/src/__tests__/DOMObserver.test.ts
+++ b/src/__tests__/DOMObserver.test.ts
@@ -216,6 +216,78 @@ describe('DOMObserver', () => {
 				})
 			})
 		})
+
+		describe('Multiple targets', () => {
+			beforeEach(() => {
+				el = _createElement('foo')
+			})
+
+			it('Resolves on EXIST for the first target found in the DOM', async () => {
+				const { node, event, target } = await instance.wait(['#foo', '#bar'])
+				expect(node).toEqual(el)
+				expect(event).toBe(DOMObserver.EXIST)
+				expect(target).toBe('#foo')
+			})
+
+			it('Resolves on EXIST for the second target when the first is absent', async () => {
+				const second = document.createElement('div')
+				second.id = 'second'
+				document.body.appendChild(second)
+				const { node, target } = await instance.wait(['#missing', '#second'])
+				expect(node.id).toBe('second')
+				expect(target).toBe('#second')
+				second.remove()
+			})
+
+			it('Resolves on ADD for whichever target is added first', async () => {
+				setTimeout(() => {
+					const div = document.createElement('div')
+					div.id = 'winner'
+					document.body.appendChild(div)
+				}, 50)
+				const { node, target } = await instance.wait(['#winner', '#loser'], { events: [DOMObserver.ADD] })
+				expect(node.id).toBe('winner')
+				expect(target).toBe('#winner')
+			})
+
+			it('Resolves on ADD for the second target when it fires first', async () => {
+				setTimeout(() => {
+					const div = document.createElement('div')
+					div.id = 'second-wins'
+					document.body.appendChild(div)
+				}, 50)
+				const { node, target } = await instance.wait(['#first-never', '#second-wins'], {
+					events: [DOMObserver.ADD],
+				})
+				expect(node.id).toBe('second-wins')
+				expect(target).toBe('#second-wins')
+			})
+
+			it('Leaves result.target undefined for a single-target call', async () => {
+				const { target } = await instance.wait('#foo')
+				expect(target).toBeUndefined()
+			})
+
+			it('Rejects with [TARGET] when any target selector is invalid', async () => {
+				await expect(instance.wait(['#foo', '##invalid'])).rejects.toThrow(DOMObserverErrors.TARGET)
+			})
+
+			it('Rejects with [TIMEOUT] when no target matches within the time limit', async () => {
+				await expect(
+					instance.wait(['#missing1', '#missing2'], { events: [DOMObserver.ADD], timeout: 50 })
+				).rejects.toThrow(DOMObserverErrors.TIMEOUT)
+			})
+
+			it('Rejects with AbortError when signal is aborted during multi-target observation', async () => {
+				const controller = new AbortController()
+				const promise = instance.wait(['#missing1', '#missing2'], {
+					events: [DOMObserver.ADD],
+					signal: controller.signal,
+				})
+				setTimeout(() => controller.abort(), 50)
+				await expect(promise).rejects.toMatchObject({ name: 'AbortError' })
+			})
+		})
 	})
 
 	describe('watch', () => {


### PR DESCRIPTION
## Summary

Extends \`wait()\` to accept an array of targets (\`DOMTarget[]\`) in addition to a single target. A single \`MutationObserver\` watches all entries and resolves on the first matching event. \`WaitResult\` gains an optional \`target\` field identifying the winning entry — \`undefined\` for single-target calls, preserving full backward compatibility.

## Changes

- \`src/DOMObserver.ts\` — \`WaitResult.target?: DOMTarget\` added; \`wait()\` gains TypeScript overloads for \`DOMTarget\` and \`DOMTarget[]\`; \`_observe()\` normalises \`target\` to an array internally, resolves all entries upfront (throwing on invalid selectors), iterates targets in EXIST/childList/attributes callbacks, and accepts an optional \`onMatch\` callback so \`wait()\` can capture the winning target; \`isDirectObservation\` updated to require a single-element target
- \`src/__tests__/DOMObserver.test.ts\` — 8 new multi-target tests: EXIST first/second target, ADD first/second target, single-target \`result.target === undefined\`, invalid selector rejection, TIMEOUT, AbortSignal
- \`README.md\` — multi-target usage example and updated \`WaitResult\` table with \`target\` field

## Test plan

- [x] \`yarn test:ci\` passes (70 tests, 100% statement coverage)
- [x] \`yarn build\` succeeds — \`WaitResult.target\` appears in generated \`.d.ts\`
- [x] No breaking changes — single-target calls are unchanged, \`result.target\` is \`undefined\`

Closes #48