### PR TITLE
feat: Validate timeout option value in wait() and watch()

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ observer.watch('#foo', (node, event) => {
 | `options`           | Object            | Options object:                                                                                                                                          |
 | - `events`          | Array             | List of [events](#events) to observe (All events are observed by default)                                                                                |
 | - `attributeFilter` | Array             | List of attribute names to observe (DOMObserver.CHANGE event only)                                                                                       |
-| - `timeout`         | Number            | Duration (in ms) after which observation stops if no matching mutation occurred. Triggers `onError` when elapsed.                                        |
+| - `timeout`         | Number            | Duration (in ms) after which observation stops if no matching mutation occurred. Triggers `onError` when elapsed. Must be `0` or a positive finite number — throws `[TIMEOUT]` otherwise. |
 | - `onError`         | Function          | Callback triggered when `timeout` elapses with no matching mutation                                                                                      |
 | - `signal`          | AbortSignal       | An `AbortSignal` to stop the observation. If already aborted, `watch()` returns immediately without observing.                                           |
 | - `once`            | Boolean           | When `true`, automatically calls `clear()` after the first matching event. Defaults to `false`.                                                          |
@@ -157,7 +157,7 @@ Once the first matching mutation occurs, the Promise resolves and the observatio
 | `target`            | Element, String, or Array  | DOM element, selector, or array of either. When an array is passed, resolves on the first match across all entries.                                      |
 | `options`           | Object            | Options object:                                                                                                                                          |
 | - `events`          | Array             | List of [events](#events) to observe (All events are observed by default)                                                                                |
-| - `timeout`         | Number            | Duration (in ms) before rejecting the Promise with a `[TIMEOUT]` error. `0` disables the timeout.                                                       |
+| - `timeout`         | Number            | Duration (in ms) before rejecting the Promise with a `[TIMEOUT]` error. `0` disables the timeout. Must be `0` or a positive finite number — rejects with `[TIMEOUT]` otherwise.          |
 | - `attributeFilter` | Array             | List of attribute names to observe (DOMObserver.CHANGE event only)                                                                                       |
 | - `signal`          | AbortSignal       | An `AbortSignal` to cancel the observation. If already aborted, the Promise rejects immediately with an `AbortError`.                                    |
 | - `root`            | Element or String | DOM element or CSS selector to use as the observation root. Only mutations within this subtree are observed. Defaults to `document.documentElement`.     |
@@ -251,7 +251,7 @@ try {
 
 | Constant | Value | Thrown by |
 |---|---|---|
-| `DOMObserverErrors.TIMEOUT` | `'[TIMEOUT]'` | `wait()`, `watch()` when `timeout` elapses |
+| `DOMObserverErrors.TIMEOUT` | `'[TIMEOUT]'` | `wait()`, `watch()` when `timeout` elapses; also when `timeout` is an invalid value (`-1`, `NaN`, `Infinity`) |
 | `DOMObserverErrors.ABORT` | `'[ABORT]'` | `wait()` when replaced by a new call |
 | `DOMObserverErrors.EVENTS` | `'[EVENTS]'` | `wait()`, `watch()` when `events` array is empty |
 | `DOMObserverErrors.TARGET` | `'[TARGET]'` | `wait()`, `watch()` when `target` is an invalid CSS selector |

--- a/src/DOMObserver.ts
+++ b/src/DOMObserver.ts
@@ -129,6 +129,7 @@ class DOMObserver {
 	 * @param options - Observation options.
 	 * @returns A Promise that resolves with the matching node, event type, and optional change metadata.
 	 * @throws `[EVENTS]` when the `events` array is empty.
+	 * @throws `[TIMEOUT]` when `timeout` is negative, `NaN`, or `Infinity`.
 	 * @throws `[TARGET]` when any target string is not a valid CSS selector.
 	 */
 	wait(target: DOMTarget, options?: WaitOptions): Promise<WaitResult>
@@ -146,6 +147,10 @@ class DOMObserver {
 	): Promise<WaitResult> {
 		if (!events?.length) {
 			return Promise.reject(new Error(`${DOMObserverErrors.EVENTS}: events array cannot be empty`))
+		}
+
+		if (timeout !== 0 && (!Number.isFinite(timeout) || timeout < 0)) {
+			return Promise.reject(new Error(`${DOMObserverErrors.TIMEOUT}: timeout must be a positive finite number`))
 		}
 
 		if (signal?.aborted) {
@@ -240,6 +245,7 @@ class DOMObserver {
 	 * @param options - Observation options.
 	 * @returns The `DOMObserver` instance, allowing method chaining.
 	 * @throws `[EVENTS]` when the `events` array is empty.
+	 * @throws `[TIMEOUT]` when `timeout` is negative, `NaN`, or `Infinity`.
 	 * @throws `[TARGET]` when `target` is a string that is not a valid CSS selector.
 	 */
 	watch(
@@ -259,6 +265,10 @@ class DOMObserver {
 	): this {
 		if (!events?.length) {
 			throw new Error(`${DOMObserverErrors.EVENTS}: events array cannot be empty`)
+		}
+
+		if (timeout !== 0 && (!Number.isFinite(timeout) || timeout < 0)) {
+			throw new Error(`${DOMObserverErrors.TIMEOUT}: timeout must be a positive finite number`)
 		}
 
 		if (signal?.aborted) {

--- a/src/DOMObserver.ts
+++ b/src/DOMObserver.ts
@@ -47,7 +47,7 @@ export interface WaitResult {
 export interface WaitOptions {
 	/** Event types to listen for. Defaults to all four event types. */
 	events?: DOMObserverEvent[]
-	/** Maximum time in milliseconds to wait before rejecting with a `[TIMEOUT]` error. `0` disables the timeout. */
+	/** Maximum time in milliseconds to wait before rejecting with a `[TIMEOUT]` error. `0` disables the timeout. Must be `0` or a positive finite number — rejects with `[TIMEOUT]` otherwise. */
 	timeout?: number
 	/** Restrict attribute observation to these attribute names. Passed directly to `MutationObserver.observe()`. */
 	attributeFilter?: string[]
@@ -67,7 +67,8 @@ export interface WatchOptions {
 	attributeFilter?: string[]
 	/**
 	 * Maximum time in milliseconds to wait for the first matching mutation before stopping observation.
-	 * The timeout is cancelled as soon as any mutation fires. `0` disables the timeout.
+	 * The timeout is cancelled as soon as any mutation fires. `0` disables the timeout. Must be `0` or
+	 * a positive finite number — throws `[TIMEOUT]` otherwise.
 	 */
 	timeout?: number
 	/** Called with a `[TIMEOUT]` error when the timeout elapses with no matching mutation. */
@@ -150,7 +151,7 @@ class DOMObserver {
 		}
 
 		if (timeout !== 0 && (!Number.isFinite(timeout) || timeout < 0)) {
-			return Promise.reject(new Error(`${DOMObserverErrors.TIMEOUT}: timeout must be a positive finite number`))
+			return Promise.reject(new Error(`${DOMObserverErrors.TIMEOUT}: timeout must be 0 or a positive finite number`))
 		}
 
 		if (signal?.aborted) {
@@ -268,7 +269,7 @@ class DOMObserver {
 		}
 
 		if (timeout !== 0 && (!Number.isFinite(timeout) || timeout < 0)) {
-			throw new Error(`${DOMObserverErrors.TIMEOUT}: timeout must be a positive finite number`)
+			throw new Error(`${DOMObserverErrors.TIMEOUT}: timeout must be 0 or a positive finite number`)
 		}
 
 		if (signal?.aborted) {

--- a/src/__tests__/DOMObserver.test.ts
+++ b/src/__tests__/DOMObserver.test.ts
@@ -86,6 +86,13 @@ describe('DOMObserver', () => {
 					await expect(() => instance.wait('#foo', { events: [] })).rejects.toThrow()
 				})
 
+				it.each([[-1], [NaN], [Infinity], [-Infinity]])(
+					'Rejects with [TIMEOUT] when timeout is %s',
+					async (value) => {
+						await expect(instance.wait('#foo', { timeout: value })).rejects.toThrow(DOMObserverErrors.TIMEOUT)
+					}
+				)
+
 				it('Rejects with [TARGET] error when selector is invalid', async () => {
 					await expect(instance.wait('##invalid')).rejects.toThrow(DOMObserverErrors.TARGET)
 				})
@@ -537,6 +544,13 @@ describe('DOMObserver', () => {
 			it('Throws when events array is empty', () => {
 				expect(() => instance.watch('#foo', onEvent, { events: [] })).toThrow(DOMObserverErrors.EVENTS)
 			})
+
+			it.each([[-1], [NaN], [Infinity], [-Infinity]])(
+				'Throws with [TIMEOUT] when timeout is %s',
+				(value) => {
+					expect(() => instance.watch('#foo', onEvent, { timeout: value })).toThrow(DOMObserverErrors.TIMEOUT)
+				}
+			)
 
 			it('Throws with [TARGET] error when selector is invalid', () => {
 				expect(() => instance.watch('##invalid', onEvent)).toThrow(DOMObserverErrors.TARGET)


### PR DESCRIPTION
## Summary

Adds explicit validation of the `timeout` option in both `wait()` and `watch()`. Any value that is neither `0` (disabled) nor a positive finite number now immediately rejects / throws with a `[TIMEOUT]` error, matching the existing validation pattern for the `events` option. Previously, values like `-1`, `NaN`, or `Infinity` were silently ignored, masking developer mistakes.

## Changes

- `src/DOMObserver.ts` — guard added in `wait()` (via `Promise.reject`) and `watch()` (via `throw`) using `timeout !== 0 && (!Number.isFinite(timeout) || timeout < 0)`; `@throws` JSDoc updated on both methods
- `src/__tests__/DOMObserver.test.ts` — `it.each` tests covering `-1`, `NaN`, `Infinity`, `-Infinity` for both `wait()` and `watch()` (8 new cases)
- `README.md` — `timeout` option descriptions updated with the valid value constraint; error constants table updated

## Test plan

- [x] `yarn test:ci` passes (81 tests, 100% statement coverage)
- [x] `wait('#foo', { timeout: -1 })` rejects with `[TIMEOUT]`
- [x] `wait('#foo', { timeout: NaN })` rejects with `[TIMEOUT]`
- [x] `wait('#foo', { timeout: Infinity })` rejects with `[TIMEOUT]`
- [x] `watch('#foo', cb, { timeout: -1 })` throws with `[TIMEOUT]`
- [x] `wait('#foo', { timeout: 0 })` and `wait('#foo', { timeout: 500 })` unaffected

Closes #49