### PR TITLE
feat(wait)!: Auto-disconnect observer after wait() resolves

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,15 @@ const { node, target } = await observer.wait(['#success', '#error'], {
 console.log(`Matched: ${target}`)
 ```
 
-Once the first matching mutation occurs, the Promise resolves and the observation stops automatically. If a `timeout` is set and elapses before any matching mutation, the Promise rejects with a `[TIMEOUT]` error.
+Once the first matching mutation occurs, the Promise resolves and the observation stops automatically — the internal observer is disconnected and all state is reset before the Promise settles. `isObserving` is `false` immediately after `await`:
+
+```javascript
+const observer = new DOMObserver()
+const { node } = await observer.wait('#foo')
+console.log(observer.isObserving) // false — auto-cleared on resolution
+```
+
+Calling `clear()` after `wait()` resolves is safe and is a no-op. If a `timeout` is set and elapses before any matching mutation, the Promise rejects with a `[TIMEOUT]` error.
 
 #### `wait` method arguments
 

--- a/src/DOMObserver.ts
+++ b/src/DOMObserver.ts
@@ -174,6 +174,7 @@ class DOMObserver {
 			}
 			const settle = (value: WaitResult) => {
 				cleanup()
+				this.clear()
 				resolve(value)
 			}
 			const cancel = (error: Error | DOMException) => {

--- a/src/__tests__/DOMObserver.test.ts
+++ b/src/__tests__/DOMObserver.test.ts
@@ -124,6 +124,20 @@ describe('DOMObserver', () => {
 					expect(instance.isObserving).toBe(false)
 				})
 
+				it('Sets isObserving to false synchronously before .then() handler runs', async () => {
+					let observingInThen: boolean | undefined
+					await instance.wait('#foo').then(() => {
+						observingInThen = instance.isObserving
+					})
+					expect(observingInThen).toBe(false)
+				})
+
+				it('Calling clear() after wait() resolves is a no-op', async () => {
+					await instance.wait('#foo')
+					expect(() => instance.clear()).not.toThrow()
+					expect(instance.isObserving).toBe(false)
+				})
+
 				it('Does not clear a subsequent watch() when timeout was set', async () => {
 					await instance.wait('#foo', { timeout: 100 })
 					instance.watch('#foo', vi.fn<OnEventCallback>(), { events: [DOMObserver.CHANGE] })


### PR DESCRIPTION
## Summary

Calls `this.clear()` inside `settle()` before `resolve()` so the internal observer is disconnected synchronously before the Promise settles. Previously, cleanup relied solely on `.finally()`, which runs after `.then()` handlers — meaning `isObserving` could be observed as `true` inside a `.then()` chained on the returned promise. The `.finally()` is kept as a safety net for the cancel/reject path.

## Changes

- `src/DOMObserver.ts` — `settle()` now calls `this.clear()` before `resolve(value)`
- `src/__tests__/DOMObserver.test.ts` — two new tests: `isObserving === false` inside `.then()` handler; `clear()` after `wait()` is a no-op
- `README.md` — explicit example showing `isObserving === false` after `await wait()`, note that `clear()` afterwards is a safe no-op

## ⚠️ Breaking changes

- **`isObserving`**: returns `false` immediately after `wait()` resolves. Code that branched on `obs.isObserving === true` right after `await obs.wait()` must be updated.
- **Migration**: no changes needed for the common `await obs.wait()` pattern. Calling `obs.clear()` after `wait()` resolves continues to work (no-op).

## Test plan

- [x] `tsc --noEmit` passes
- [x] All 83 tests pass (`vitest run`)
- [x] Coverage remains at 100% statements/functions/lines
- [x] `isObserving === false` verified inside `.then()` handler (new test)
- [x] Double `clear()` after `wait()` is safe (new test)

Closes #50