### PR TITLE
feat(errors)!: Replace magic string errors with typed Error subclasses

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ observer.watch('#foo', (node, event) => {
 | `options`           | Object            | Options object:                                                                                                                                          |
 | - `events`          | Array             | List of [events](#events) to observe (All events are observed by default)                                                                                |
 | - `attributeFilter` | Array             | List of attribute names to observe (DOMObserver.CHANGE event only)                                                                                       |
-| - `timeout`         | Number            | Duration (in ms) after which observation stops if no matching mutation occurred. Triggers `onError` when elapsed. Must be `0` or a positive finite number — throws `[TIMEOUT]` otherwise. |
+| - `timeout`         | Number            | Duration (in ms) after which observation stops if no matching mutation occurred. Triggers `onError` with a `TimeoutError` when elapsed. Must be `0` or a positive finite number — throws `InvalidOptionsError` otherwise. |
 | - `onError`         | Function          | Callback triggered when `timeout` elapses with no matching mutation                                                                                      |
 | - `signal`          | AbortSignal       | An `AbortSignal` to stop the observation. If already aborted, `watch()` returns immediately without observing.                                           |
 | - `once`            | Boolean           | When `true`, automatically calls `clear()` after the first matching event. Defaults to `false`.                                                          |
@@ -156,7 +156,7 @@ const { node } = await observer.wait('#foo')
 console.log(observer.isObserving) // false — auto-cleared on resolution
 ```
 
-Calling `clear()` after `wait()` resolves is safe and is a no-op. If a `timeout` is set and elapses before any matching mutation, the Promise rejects with a `[TIMEOUT]` error.
+Calling `clear()` after `wait()` resolves is safe and is a no-op. If a `timeout` is set and elapses before any matching mutation, the Promise rejects with a `TimeoutError`.
 
 #### `wait` method arguments
 
@@ -165,7 +165,7 @@ Calling `clear()` after `wait()` resolves is safe and is a no-op. If a `timeout`
 | `target`            | Element, String, or Array  | DOM element, selector, or array of either. When an array is passed, resolves on the first match across all entries.                                      |
 | `options`           | Object            | Options object:                                                                                                                                          |
 | - `events`          | Array             | List of [events](#events) to observe (All events are observed by default)                                                                                |
-| - `timeout`         | Number            | Duration (in ms) before rejecting the Promise with a `[TIMEOUT]` error. `0` disables the timeout. Must be `0` or a positive finite number — rejects with `[TIMEOUT]` otherwise.          |
+| - `timeout`         | Number            | Duration (in ms) before rejecting the Promise with a `TimeoutError`. `0` disables the timeout. Must be `0` or a positive finite number — rejects with `InvalidOptionsError` otherwise. |
 | - `attributeFilter` | Array             | List of attribute names to observe (DOMObserver.CHANGE event only)                                                                                       |
 | - `signal`          | AbortSignal       | An `AbortSignal` to cancel the observation. If already aborted, the Promise rejects immediately with an `AbortError`.                                    |
 | - `root`            | Element or String | DOM element or CSS selector to use as the observation root. Only mutations within this subtree are observed. Defaults to `document.documentElement`.     |
@@ -224,45 +224,45 @@ observer.clear()
 observer.clear().watch('#bar', onEvent)
 ```
 
-> **Note:** Calling `wait()` or `watch()` on an instance that already has a pending `wait()` Promise will automatically reject that Promise with an `[ABORT]` error before starting the new observation. Handle this rejection if necessary:
+> **Note:** Calling `wait()` or `watch()` on an instance that already has a pending `wait()` Promise will automatically reject that Promise with an `ObservationAbortedError` before starting the new observation. Handle this rejection if necessary:
 >
 > ```javascript
-> import { DOMObserver, DOMObserverErrors } from '@untemps/dom-observer'
+> import { DOMObserver, ObservationAbortedError } from '@untemps/dom-observer'
 >
 > const observer = new DOMObserver()
 > observer.wait('#foo').catch((err) => {
->     if (err.message.startsWith(DOMObserverErrors.ABORT)) return // replaced by a new observation
+>     if (err instanceof ObservationAbortedError) return // replaced by a new observation
 >     throw err
 > })
-> observer.wait('#bar')  // previous promise is rejected with [ABORT]
-> observer.watch('#baz', onEvent)  // also rejects a pending wait() with [ABORT]
+> observer.wait('#bar')  // previous promise is rejected with ObservationAbortedError
+> observer.watch('#baz', onEvent)  // also rejects a pending wait() with ObservationAbortedError
 > ```
 
-## Error constants
+## Error classes
 
-The library exports a `DOMObserverErrors` object and a `DOMObserverErrorCode` type for reliable error handling without fragile string matching:
+The library exports typed `Error` subclasses for reliable error handling with `instanceof` checks:
 
 ```typescript
-import { DOMObserver, DOMObserverErrors } from '@untemps/dom-observer'
+import { DOMObserver, TimeoutError, ObservationAbortedError } from '@untemps/dom-observer'
 
 try {
     await observer.wait('#foo', { timeout: 500 })
 } catch (e) {
-    const message = (e as Error).message
-    if (message.startsWith(DOMObserverErrors.TIMEOUT)) {
-        // handle timeout
-    } else if (message.startsWith(DOMObserverErrors.ABORT)) {
+    if (e instanceof TimeoutError) {
+        console.log(`Timed out waiting for ${e.target} after ${e.timeout}ms`)
+    } else if (e instanceof ObservationAbortedError) {
         // replaced by another observation
     }
 }
 ```
 
-| Constant | Value | Thrown by |
+| Class | Properties | Thrown by |
 |---|---|---|
-| `DOMObserverErrors.TIMEOUT` | `'[TIMEOUT]'` | `wait()`, `watch()` when `timeout` elapses; also when `timeout` is an invalid value (`-1`, `NaN`, `Infinity`) |
-| `DOMObserverErrors.ABORT` | `'[ABORT]'` | `wait()` when replaced by a new call |
-| `DOMObserverErrors.EVENTS` | `'[EVENTS]'` | `wait()`, `watch()` when `events` array is empty |
-| `DOMObserverErrors.TARGET` | `'[TARGET]'` | `wait()`, `watch()` when `target` is an invalid CSS selector |
+| `TimeoutError` | `target: DOMTarget \| DOMTarget[]`, `timeout: number` | `wait()`, `watch()` when `timeout` elapses |
+| `ObservationAbortedError` | — | `wait()` when replaced by a new call |
+| `InvalidEventsError` | — | `wait()`, `watch()` when `events` array is empty |
+| `InvalidTargetError` | `selector: string` | `wait()`, `watch()` when `target` is an invalid CSS selector |
+| `InvalidOptionsError` | — | `wait()`, `watch()` when an option value is invalid (e.g. negative `timeout`) |
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Calling `clear()` after `wait()` resolves is safe and is a no-op. If a `timeout`
 | `target`            | Element, String, or Array  | DOM element, selector, or array of either. When an array is passed, resolves on the first match across all entries.                                      |
 | `options`           | Object            | Options object:                                                                                                                                          |
 | - `events`          | Array             | List of [events](#events) to observe (All events are observed by default)                                                                                |
-| - `timeout`         | Number            | Duration (in ms) before rejecting the Promise with a `TimeoutError`. `0` disables the timeout. Must be `0` or a positive finite number — rejects with `InvalidOptionsError` otherwise. |
+| - `timeout`         | Number            | Duration (in ms) before rejecting the Promise with a `TimeoutError`. `0` disables the timeout. Must be `0` or a positive finite number — rejects with `InvalidTimeoutError` otherwise. |
 | - `attributeFilter` | Array             | List of attribute names to observe (DOMObserver.CHANGE event only)                                                                                       |
 | - `signal`          | AbortSignal       | An `AbortSignal` to cancel the observation. If already aborted, the Promise rejects immediately with an `AbortError`.                                    |
 | - `root`            | Element or String | DOM element or CSS selector to use as the observation root. Only mutations within this subtree are observed. Defaults to `document.documentElement`.     |

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ observer.watch('#foo', (node, event) => {
 | `options`           | Object            | Options object:                                                                                                                                          |
 | - `events`          | Array             | List of [events](#events) to observe (All events are observed by default)                                                                                |
 | - `attributeFilter` | Array             | List of attribute names to observe (DOMObserver.CHANGE event only)                                                                                       |
-| - `timeout`         | Number            | Duration (in ms) after which observation stops if no matching mutation occurred. Triggers `onError` with a `TimeoutError` when elapsed. Must be `0` or a positive finite number — throws `InvalidOptionsError` otherwise. |
+| - `timeout`         | Number            | Duration (in ms) after which observation stops if no matching mutation occurred. Triggers `onError` with a `TimeoutError` when elapsed. Must be `0` or a positive finite number — throws `InvalidTimeoutError` otherwise. |
 | - `onError`         | Function          | Callback triggered when `timeout` elapses with no matching mutation                                                                                      |
 | - `signal`          | AbortSignal       | An `AbortSignal` to stop the observation. If already aborted, `watch()` returns immediately without observing.                                           |
 | - `once`            | Boolean           | When `true`, automatically calls `clear()` after the first matching event. Defaults to `false`.                                                          |
@@ -262,7 +262,8 @@ try {
 | `ObservationAbortedError` | — | `wait()` when replaced by a new call |
 | `InvalidEventsError` | — | `wait()`, `watch()` when `events` array is empty |
 | `InvalidTargetError` | `selector: string` | `wait()`, `watch()` when `target` is an invalid CSS selector |
-| `InvalidOptionsError` | — | `wait()`, `watch()` when an option value is invalid (e.g. negative `timeout`) |
+| `InvalidOptionsError` | — | Base class for all invalid-option errors; catch-all via `instanceof` |
+| `InvalidTimeoutError` | — | `wait()`, `watch()` when `timeout` is an invalid value (negative, `NaN`, `Infinity`); extends `InvalidOptionsError` |
 
 ## Example
 

--- a/src/DOMObserver.ts
+++ b/src/DOMObserver.ts
@@ -1,9 +1,9 @@
 import { InvalidEventsError, InvalidOptionsError, ObservationAbortedError, TimeoutError } from './DOMObserverErrors'
+import type { DOMTarget } from './types'
 import isElement from './utils/isElement'
 import resolveDOMTarget from './utils/resolveDOMTarget'
 
-/** A CSS selector string or a direct DOM Element reference used to identify the observed target. */
-export type DOMTarget = Element | string
+export type { DOMTarget }
 
 /** Union of all event types emitted by DOMObserver. */
 export type DOMObserverEvent = 'DOMObserver_exist' | 'DOMObserver_add' | 'DOMObserver_remove' | 'DOMObserver_change'
@@ -151,7 +151,7 @@ class DOMObserver {
 		}
 
 		if (timeout !== 0 && (!Number.isFinite(timeout) || timeout < 0)) {
-			return Promise.reject(new InvalidOptionsError('timeout must be 0 or a positive finite number'))
+			return Promise.reject(new InvalidOptionsError('Timeout must be 0 or a positive finite number'))
 		}
 
 		if (signal?.aborted) {
@@ -255,7 +255,7 @@ class DOMObserver {
 		}
 
 		if (timeout !== 0 && (!Number.isFinite(timeout) || timeout < 0)) {
-			throw new InvalidOptionsError('timeout must be 0 or a positive finite number')
+			throw new InvalidOptionsError('Timeout must be 0 or a positive finite number')
 		}
 
 		if (signal?.aborted) {

--- a/src/DOMObserver.ts
+++ b/src/DOMObserver.ts
@@ -1,4 +1,4 @@
-import { DOMObserverErrors } from './DOMObserverErrors'
+import { InvalidEventsError, InvalidOptionsError, InvalidTargetError, ObservationAbortedError, TimeoutError } from './DOMObserverErrors'
 import isElement from './utils/isElement'
 import resolveDOMTarget from './utils/resolveDOMTarget'
 
@@ -47,7 +47,7 @@ export interface WaitResult {
 export interface WaitOptions {
 	/** Event types to listen for. Defaults to all four event types. */
 	events?: DOMObserverEvent[]
-	/** Maximum time in milliseconds to wait before rejecting with a `[TIMEOUT]` error. `0` disables the timeout. Must be `0` or a positive finite number — rejects with `[TIMEOUT]` otherwise. */
+	/** Maximum time in milliseconds to wait before rejecting with a `TimeoutError`. `0` disables the timeout. Must be `0` or a positive finite number — rejects with `InvalidOptionsError` otherwise. */
 	timeout?: number
 	/** Restrict attribute observation to these attribute names. Passed directly to `MutationObserver.observe()`. */
 	attributeFilter?: string[]
@@ -68,10 +68,10 @@ export interface WatchOptions {
 	/**
 	 * Maximum time in milliseconds to wait for the first matching mutation before stopping observation.
 	 * The timeout is cancelled as soon as any mutation fires. `0` disables the timeout. Must be `0` or
-	 * a positive finite number — throws `[TIMEOUT]` otherwise.
+	 * a positive finite number — throws `InvalidOptionsError` otherwise.
 	 */
 	timeout?: number
-	/** Called with a `[TIMEOUT]` error when the timeout elapses with no matching mutation. */
+	/** Called with a `TimeoutError` when the timeout elapses with no matching mutation. */
 	onError?: (error: Error) => void
 	/** When provided, aborting the signal stops observation immediately. */
 	signal?: AbortSignal
@@ -119,7 +119,7 @@ class DOMObserver {
 	 * resolves synchronously on the next microtask. The observer is automatically disconnected as soon
 	 * as the Promise settles — whether by resolution, rejection, timeout, or abort.
 	 *
-	 * Calling `wait()` while a previous call is still pending rejects the previous Promise with `[ABORT]`
+	 * Calling `wait()` while a previous call is still pending rejects the previous Promise with `ObservationAbortedError`
 	 * and starts a fresh observation.
 	 *
 	 * When an array of targets is passed, the Promise resolves as soon as any one of them fires a
@@ -129,9 +129,9 @@ class DOMObserver {
 	 * @param target - CSS selector, Element, or array of either to observe.
 	 * @param options - Observation options.
 	 * @returns A Promise that resolves with the matching node, event type, and optional change metadata.
-	 * @throws `[EVENTS]` when the `events` array is empty.
-	 * @throws `[TIMEOUT]` when `timeout` is negative, `NaN`, or `Infinity`.
-	 * @throws `[TARGET]` when any target string is not a valid CSS selector.
+	 * @throws `InvalidEventsError` when the `events` array is empty.
+	 * @throws `InvalidOptionsError` when `timeout` is negative, `NaN`, or `Infinity`.
+	 * @throws `InvalidTargetError` when any target string is not a valid CSS selector.
 	 */
 	wait(target: DOMTarget, options?: WaitOptions): Promise<WaitResult>
 	wait(targets: DOMTarget[], options?: WaitOptions): Promise<WaitResult>
@@ -147,18 +147,18 @@ class DOMObserver {
 		}: WaitOptions = {}
 	): Promise<WaitResult> {
 		if (!events?.length) {
-			return Promise.reject(new Error(`${DOMObserverErrors.EVENTS}: events array cannot be empty`))
+			return Promise.reject(new InvalidEventsError())
 		}
 
 		if (timeout !== 0 && (!Number.isFinite(timeout) || timeout < 0)) {
-			return Promise.reject(new Error(`${DOMObserverErrors.TIMEOUT}: timeout must be 0 or a positive finite number`))
+			return Promise.reject(new InvalidOptionsError('timeout must be 0 or a positive finite number'))
 		}
 
 		if (signal?.aborted) {
 			return Promise.reject(signal.reason ?? new DOMException('Aborted', 'AbortError'))
 		}
 
-		this._pendingReject?.(new Error(`${DOMObserverErrors.ABORT}: Observation replaced by a new wait() call`))
+		this._pendingReject?.(new ObservationAbortedError('Observation replaced by a new wait() call'))
 		this._pendingReject = null
 		this.clear()
 
@@ -198,20 +198,8 @@ class DOMObserver {
 			}
 
 			if (timeout > 0) {
-				const formatTarget = (t: DOMTarget): string =>
-					isElement(t) ? `<${t.tagName.toLowerCase()}${t.id ? `#${t.id}` : ''}>` : String(t)
-				const targetLabel = isMulti
-					? `[${(target as DOMTarget[]).map(formatTarget).join(', ')}]`
-					: formatTarget(target as DOMTarget)
 				this._timeout = setTimeout(
-					() =>
-						cancel(
-							new Error(
-								isMulti
-									? `${DOMObserverErrors.TIMEOUT}: None of ${targetLabel} could be found after ${timeout}ms`
-									: `${DOMObserverErrors.TIMEOUT}: Element ${targetLabel} cannot be found after ${timeout}ms`
-							)
-						),
+					() => cancel(new TimeoutError(target, timeout)),
 					timeout
 				)
 			}
@@ -230,7 +218,7 @@ class DOMObserver {
 	 * If the target already exists in the DOM and `EXIST` is among the requested events, `onEvent` is
 	 * called synchronously before this method returns.
 	 *
-	 * Calling `watch()` while a previous `wait()` is still pending rejects that Promise with `[ABORT]`
+	 * Calling `watch()` while a previous `wait()` is still pending rejects that Promise with `ObservationAbortedError`
 	 * and starts a fresh observation.
 	 *
 	 * When `timeout` is set, the observation stops automatically after the first matching mutation —
@@ -246,9 +234,9 @@ class DOMObserver {
 	 * @param onEvent - Callback invoked on every matching event.
 	 * @param options - Observation options.
 	 * @returns The `DOMObserver` instance, allowing method chaining.
-	 * @throws `[EVENTS]` when the `events` array is empty.
-	 * @throws `[TIMEOUT]` when `timeout` is negative, `NaN`, or `Infinity`.
-	 * @throws `[TARGET]` when `target` is a string that is not a valid CSS selector.
+	 * @throws `InvalidEventsError` when the `events` array is empty.
+	 * @throws `InvalidOptionsError` when `timeout` is negative, `NaN`, or `Infinity`.
+	 * @throws `InvalidTargetError` when `target` is a string that is not a valid CSS selector.
 	 */
 	watch(
 		target: DOMTarget,
@@ -266,18 +254,18 @@ class DOMObserver {
 		}: WatchOptions = {}
 	): this {
 		if (!events?.length) {
-			throw new Error(`${DOMObserverErrors.EVENTS}: events array cannot be empty`)
+			throw new InvalidEventsError()
 		}
 
 		if (timeout !== 0 && (!Number.isFinite(timeout) || timeout < 0)) {
-			throw new Error(`${DOMObserverErrors.TIMEOUT}: timeout must be 0 or a positive finite number`)
+			throw new InvalidOptionsError('timeout must be 0 or a positive finite number')
 		}
 
 		if (signal?.aborted) {
 			return this
 		}
 
-		this._pendingReject?.(new Error(`${DOMObserverErrors.ABORT}: Observation replaced by a new watch() call`))
+		this._pendingReject?.(new ObservationAbortedError('Observation replaced by a new watch() call'))
 		this._pendingReject = null
 		this.clear()
 
@@ -296,9 +284,7 @@ class DOMObserver {
 			}
 			this._timeout = setTimeout(() => {
 				this.clear()
-				onError?.(
-					new Error(`${DOMObserverErrors.TIMEOUT}: Element ${target} cannot be found after ${timeout}ms`)
-				)
+				onError?.(new TimeoutError(target, timeout))
 			}, timeout)
 		}
 		if (debounce > 0) {

--- a/src/DOMObserver.ts
+++ b/src/DOMObserver.ts
@@ -1,4 +1,4 @@
-import { InvalidEventsError, InvalidOptionsError, ObservationAbortedError, TimeoutError } from './DOMObserverErrors'
+import { InvalidEventsError, InvalidTimeoutError, ObservationAbortedError, TimeoutError } from './DOMObserverErrors'
 import type { DOMTarget } from './types'
 import isElement from './utils/isElement'
 import resolveDOMTarget from './utils/resolveDOMTarget'
@@ -47,7 +47,7 @@ export interface WaitResult {
 export interface WaitOptions {
 	/** Event types to listen for. Defaults to all four event types. */
 	events?: DOMObserverEvent[]
-	/** Maximum time in milliseconds to wait before rejecting with a `TimeoutError`. `0` disables the timeout. Must be `0` or a positive finite number — rejects with `InvalidOptionsError` otherwise. */
+	/** Maximum time in milliseconds to wait before rejecting with a `TimeoutError`. `0` disables the timeout. Must be `0` or a positive finite number — rejects with `InvalidTimeoutError` otherwise. */
 	timeout?: number
 	/** Restrict attribute observation to these attribute names. Passed directly to `MutationObserver.observe()`. */
 	attributeFilter?: string[]
@@ -68,7 +68,7 @@ export interface WatchOptions {
 	/**
 	 * Maximum time in milliseconds to wait for the first matching mutation before stopping observation.
 	 * The timeout is cancelled as soon as any mutation fires. `0` disables the timeout. Must be `0` or
-	 * a positive finite number — throws `InvalidOptionsError` otherwise.
+	 * a positive finite number — throws `InvalidTimeoutError` otherwise.
 	 */
 	timeout?: number
 	/** Called with a `TimeoutError` when the timeout elapses with no matching mutation. */
@@ -130,7 +130,7 @@ class DOMObserver {
 	 * @param options - Observation options.
 	 * @returns A Promise that resolves with the matching node, event type, and optional change metadata.
 	 * @throws `InvalidEventsError` when the `events` array is empty.
-	 * @throws `InvalidOptionsError` when `timeout` is negative, `NaN`, or `Infinity`.
+	 * @throws `InvalidTimeoutError` when `timeout` is negative, `NaN`, or `Infinity`.
 	 * @throws `InvalidTargetError` when any target string is not a valid CSS selector.
 	 */
 	wait(target: DOMTarget, options?: WaitOptions): Promise<WaitResult>
@@ -151,7 +151,7 @@ class DOMObserver {
 		}
 
 		if (timeout !== 0 && (!Number.isFinite(timeout) || timeout < 0)) {
-			return Promise.reject(new InvalidOptionsError())
+			return Promise.reject(new InvalidTimeoutError())
 		}
 
 		if (signal?.aborted) {
@@ -232,7 +232,7 @@ class DOMObserver {
 	 * @param options - Observation options.
 	 * @returns The `DOMObserver` instance, allowing method chaining.
 	 * @throws `InvalidEventsError` when the `events` array is empty.
-	 * @throws `InvalidOptionsError` when `timeout` is negative, `NaN`, or `Infinity`.
+	 * @throws `InvalidTimeoutError` when `timeout` is negative, `NaN`, or `Infinity`.
 	 * @throws `InvalidTargetError` when `target` is a string that is not a valid CSS selector.
 	 */
 	watch(
@@ -255,7 +255,7 @@ class DOMObserver {
 		}
 
 		if (timeout !== 0 && (!Number.isFinite(timeout) || timeout < 0)) {
-			throw new InvalidOptionsError()
+			throw new InvalidTimeoutError()
 		}
 
 		if (signal?.aborted) {

--- a/src/DOMObserver.ts
+++ b/src/DOMObserver.ts
@@ -1,4 +1,4 @@
-import { InvalidEventsError, InvalidOptionsError, InvalidTargetError, ObservationAbortedError, TimeoutError } from './DOMObserverErrors'
+import { InvalidEventsError, InvalidOptionsError, ObservationAbortedError, TimeoutError } from './DOMObserverErrors'
 import isElement from './utils/isElement'
 import resolveDOMTarget from './utils/resolveDOMTarget'
 
@@ -198,10 +198,7 @@ class DOMObserver {
 			}
 
 			if (timeout > 0) {
-				this._timeout = setTimeout(
-					() => cancel(new TimeoutError(target, timeout)),
-					timeout
-				)
+				this._timeout = setTimeout(() => cancel(new TimeoutError(target, timeout)), timeout)
 			}
 
 			this._observe(target, callback, { events, attributeFilter, root, filter }, (t) => {

--- a/src/DOMObserver.ts
+++ b/src/DOMObserver.ts
@@ -151,7 +151,7 @@ class DOMObserver {
 		}
 
 		if (timeout !== 0 && (!Number.isFinite(timeout) || timeout < 0)) {
-			return Promise.reject(new InvalidOptionsError('Timeout must be 0 or a positive finite number'))
+			return Promise.reject(new InvalidOptionsError())
 		}
 
 		if (signal?.aborted) {
@@ -255,7 +255,7 @@ class DOMObserver {
 		}
 
 		if (timeout !== 0 && (!Number.isFinite(timeout) || timeout < 0)) {
-			throw new InvalidOptionsError('Timeout must be 0 or a positive finite number')
+			throw new InvalidOptionsError()
 		}
 
 		if (signal?.aborted) {

--- a/src/DOMObserverErrors.ts
+++ b/src/DOMObserverErrors.ts
@@ -1,13 +1,13 @@
-import type { DOMTarget } from './DOMObserver'
+import type { DOMTarget } from './types'
 
 export class TimeoutError extends Error {
 	readonly target: DOMTarget | DOMTarget[]
 	readonly timeout: number
 
 	constructor(target: DOMTarget | DOMTarget[], timeout: number) {
-		const label = Array.isArray(target)
-			? `None of [${(target as DOMTarget[]).join(', ')}]`
-			: `Element "${target}"`
+		const fmt = (t: DOMTarget): string =>
+			t instanceof Element ? `<${t.tagName.toLowerCase()}${t.id ? `#${t.id}` : ''}>` : String(t)
+		const label = Array.isArray(target) ? `None of [${target.map(fmt).join(', ')}]` : fmt(target)
 		super(`${label} could not be found after ${timeout}ms`)
 		this.name = 'TimeoutError'
 		this.target = target
@@ -16,15 +16,15 @@ export class TimeoutError extends Error {
 }
 
 export class ObservationAbortedError extends Error {
-	constructor(reason?: string) {
-		super(reason ?? 'Observation replaced by a newer call')
+	constructor(reason: string) {
+		super(reason)
 		this.name = 'ObservationAbortedError'
 	}
 }
 
 export class InvalidEventsError extends Error {
 	constructor() {
-		super('events array cannot be empty')
+		super('Events array cannot be empty')
 		this.name = 'InvalidEventsError'
 	}
 }

--- a/src/DOMObserverErrors.ts
+++ b/src/DOMObserverErrors.ts
@@ -41,8 +41,15 @@ export class InvalidTargetError extends Error {
 }
 
 export class InvalidOptionsError extends Error {
+	constructor(message: string) {
+		super(message)
+		this.name = 'InvalidOptionsError'
+	}
+}
+
+export class InvalidTimeoutError extends InvalidOptionsError {
 	constructor() {
 		super('Timeout must be 0 or a positive finite number')
-		this.name = 'InvalidOptionsError'
+		this.name = 'InvalidTimeoutError'
 	}
 }

--- a/src/DOMObserverErrors.ts
+++ b/src/DOMObserverErrors.ts
@@ -1,13 +1,14 @@
 import type { DOMTarget } from './types'
 
+const formatTarget = (t: DOMTarget): string =>
+	t instanceof Element ? `<${t.tagName.toLowerCase()}${t.id ? `#${t.id}` : ''}>` : String(t)
+
 export class TimeoutError extends Error {
 	readonly target: DOMTarget | DOMTarget[]
 	readonly timeout: number
 
 	constructor(target: DOMTarget | DOMTarget[], timeout: number) {
-		const fmt = (t: DOMTarget): string =>
-			t instanceof Element ? `<${t.tagName.toLowerCase()}${t.id ? `#${t.id}` : ''}>` : String(t)
-		const label = Array.isArray(target) ? `None of [${target.map(fmt).join(', ')}]` : fmt(target)
+		const label = Array.isArray(target) ? `None of [${target.map(formatTarget).join(', ')}]` : formatTarget(target)
 		super(`${label} could not be found after ${timeout}ms`)
 		this.name = 'TimeoutError'
 		this.target = target
@@ -40,8 +41,8 @@ export class InvalidTargetError extends Error {
 }
 
 export class InvalidOptionsError extends Error {
-	constructor(message: string) {
-		super(message)
+	constructor() {
+		super('Timeout must be 0 or a positive finite number')
 		this.name = 'InvalidOptionsError'
 	}
 }

--- a/src/DOMObserverErrors.ts
+++ b/src/DOMObserverErrors.ts
@@ -1,8 +1,47 @@
-export const DOMObserverErrors = {
-	TIMEOUT: '[TIMEOUT]',
-	ABORT: '[ABORT]',
-	EVENTS: '[EVENTS]',
-	TARGET: '[TARGET]',
-} as const
+import type { DOMTarget } from './DOMObserver'
 
-export type DOMObserverErrorCode = (typeof DOMObserverErrors)[keyof typeof DOMObserverErrors]
+export class TimeoutError extends Error {
+	readonly target: DOMTarget | DOMTarget[]
+	readonly timeout: number
+
+	constructor(target: DOMTarget | DOMTarget[], timeout: number) {
+		const label = Array.isArray(target)
+			? `None of [${(target as DOMTarget[]).join(', ')}]`
+			: `Element "${target}"`
+		super(`${label} could not be found after ${timeout}ms`)
+		this.name = 'TimeoutError'
+		this.target = target
+		this.timeout = timeout
+	}
+}
+
+export class ObservationAbortedError extends Error {
+	constructor(reason?: string) {
+		super(reason ?? 'Observation replaced by a newer call')
+		this.name = 'ObservationAbortedError'
+	}
+}
+
+export class InvalidEventsError extends Error {
+	constructor() {
+		super('events array cannot be empty')
+		this.name = 'InvalidEventsError'
+	}
+}
+
+export class InvalidTargetError extends Error {
+	readonly selector: string
+
+	constructor(selector: string) {
+		super(`"${selector}" is not a valid CSS selector`)
+		this.name = 'InvalidTargetError'
+		this.selector = selector
+	}
+}
+
+export class InvalidOptionsError extends Error {
+	constructor(message: string) {
+		super(message)
+		this.name = 'InvalidOptionsError'
+	}
+}

--- a/src/__tests__/DOMObserver.test.ts
+++ b/src/__tests__/DOMObserver.test.ts
@@ -4,8 +4,8 @@ import {
 	InvalidOptionsError,
 	InvalidTargetError,
 	ObservationAbortedError,
-	TimeoutError,
 	type OnEventCallback,
+	TimeoutError,
 } from '../index'
 
 describe('DOMObserver', () => {
@@ -94,12 +94,14 @@ describe('DOMObserver', () => {
 					await expect(() => instance.wait('#foo', { events: [] })).rejects.toThrow(InvalidEventsError)
 				})
 
-				it.each([[-1], [NaN], [Infinity], [-Infinity]])(
-					'Rejects with InvalidOptionsError when timeout is %s',
-					async (value) => {
-						await expect(instance.wait('#foo', { timeout: value })).rejects.toThrow(InvalidOptionsError)
-					}
-				)
+				it.each([
+					[-1],
+					[NaN],
+					[Infinity],
+					[-Infinity],
+				])('Rejects with InvalidOptionsError when timeout is %s', async (value) => {
+					await expect(instance.wait('#foo', { timeout: value })).rejects.toThrow(InvalidOptionsError)
+				})
 
 				it('Rejects with InvalidTargetError when selector is invalid', async () => {
 					await expect(instance.wait('##invalid')).rejects.toThrow(InvalidTargetError)
@@ -567,12 +569,14 @@ describe('DOMObserver', () => {
 				expect(() => instance.watch('#foo', onEvent, { events: [] })).toThrow(InvalidEventsError)
 			})
 
-			it.each([[-1], [NaN], [Infinity], [-Infinity]])(
-				'Throws InvalidOptionsError when timeout is %s',
-				(value) => {
-					expect(() => instance.watch('#foo', onEvent, { timeout: value })).toThrow(InvalidOptionsError)
-				}
-			)
+			it.each([
+				[-1],
+				[NaN],
+				[Infinity],
+				[-Infinity],
+			])('Throws InvalidOptionsError when timeout is %s', (value) => {
+				expect(() => instance.watch('#foo', onEvent, { timeout: value })).toThrow(InvalidOptionsError)
+			})
 
 			it('Throws InvalidTargetError when selector is invalid', () => {
 				expect(() => instance.watch('##invalid', onEvent)).toThrow(InvalidTargetError)
@@ -733,9 +737,23 @@ describe('Error classes', () => {
 		expect(err.timeout).toBe(500)
 	})
 
+	it('TimeoutError formats selector targets in message', () => {
+		const err = new TimeoutError('#foo', 500)
+		expect(err.message).toBe('#foo could not be found after 500ms')
+	})
+
+	it('TimeoutError formats Element targets in message', () => {
+		const el = document.createElement('div')
+		el.id = 'bar'
+		const err = new TimeoutError(el, 300)
+		expect(err.message).toBe('<div#bar> could not be found after 300ms')
+		expect(err.target).toBe(el)
+	})
+
 	it('TimeoutError handles array targets', () => {
 		const err = new TimeoutError(['#a', '#b'], 200)
 		expect(err.target).toEqual(['#a', '#b'])
+		expect(err.message).toBe('None of [#a, #b] could not be found after 200ms')
 	})
 
 	it('ObservationAbortedError has correct name', () => {

--- a/src/__tests__/DOMObserver.test.ts
+++ b/src/__tests__/DOMObserver.test.ts
@@ -2,6 +2,7 @@ import {
 	DOMObserver,
 	InvalidEventsError,
 	InvalidOptionsError,
+	InvalidTimeoutError,
 	InvalidTargetError,
 	ObservationAbortedError,
 	type OnEventCallback,
@@ -99,8 +100,8 @@ describe('DOMObserver', () => {
 					[NaN],
 					[Infinity],
 					[-Infinity],
-				])('Rejects with InvalidOptionsError when timeout is %s', async (value) => {
-					await expect(instance.wait('#foo', { timeout: value })).rejects.toThrow(InvalidOptionsError)
+				])('Rejects with InvalidTimeoutError when timeout is %s', async (value) => {
+					await expect(instance.wait('#foo', { timeout: value })).rejects.toThrow(InvalidTimeoutError)
 				})
 
 				it('Rejects with InvalidTargetError when selector is invalid', async () => {
@@ -574,8 +575,8 @@ describe('DOMObserver', () => {
 				[NaN],
 				[Infinity],
 				[-Infinity],
-			])('Throws InvalidOptionsError when timeout is %s', (value) => {
-				expect(() => instance.watch('#foo', onEvent, { timeout: value })).toThrow(InvalidOptionsError)
+			])('Throws InvalidTimeoutError when timeout is %s', (value) => {
+				expect(() => instance.watch('#foo', onEvent, { timeout: value })).toThrow(InvalidTimeoutError)
 			})
 
 			it('Throws InvalidTargetError when selector is invalid', () => {
@@ -776,10 +777,22 @@ describe('Error classes', () => {
 		expect(err.selector).toBe('##bad')
 	})
 
-	it('InvalidOptionsError has correct name and baked-in message', () => {
-		const err = new InvalidOptionsError()
+	it('InvalidOptionsError is a generic base with custom message', () => {
+		const err = new InvalidOptionsError('Some option is invalid')
 		expect(err).toBeInstanceOf(InvalidOptionsError)
 		expect(err.name).toBe('InvalidOptionsError')
+		expect(err.message).toBe('Some option is invalid')
+	})
+
+	it('InvalidTimeoutError has correct name and baked-in message', () => {
+		const err = new InvalidTimeoutError()
+		expect(err).toBeInstanceOf(InvalidTimeoutError)
+		expect(err.name).toBe('InvalidTimeoutError')
 		expect(err.message).toBe('Timeout must be 0 or a positive finite number')
+	})
+
+	it('InvalidTimeoutError is an instance of InvalidOptionsError', () => {
+		const err = new InvalidTimeoutError()
+		expect(err).toBeInstanceOf(InvalidOptionsError)
 	})
 })

--- a/src/__tests__/DOMObserver.test.ts
+++ b/src/__tests__/DOMObserver.test.ts
@@ -776,10 +776,10 @@ describe('Error classes', () => {
 		expect(err.selector).toBe('##bad')
 	})
 
-	it('InvalidOptionsError has correct name', () => {
-		const err = new InvalidOptionsError('timeout must be positive')
+	it('InvalidOptionsError has correct name and baked-in message', () => {
+		const err = new InvalidOptionsError()
 		expect(err).toBeInstanceOf(InvalidOptionsError)
 		expect(err.name).toBe('InvalidOptionsError')
-		expect(err.message).toBe('timeout must be positive')
+		expect(err.message).toBe('Timeout must be 0 or a positive finite number')
 	})
 })

--- a/src/__tests__/DOMObserver.test.ts
+++ b/src/__tests__/DOMObserver.test.ts
@@ -1,4 +1,12 @@
-import { DOMObserver, DOMObserverErrors, type OnEventCallback } from '../index'
+import {
+	DOMObserver,
+	InvalidEventsError,
+	InvalidOptionsError,
+	InvalidTargetError,
+	ObservationAbortedError,
+	TimeoutError,
+	type OnEventCallback,
+} from '../index'
 
 describe('DOMObserver', () => {
 	let instance: DOMObserver
@@ -72,33 +80,33 @@ describe('DOMObserver', () => {
 
 				it('Rejects promise when an element is not found after timeout is elapsed', async () => {
 					await expect(instance.wait('#bar', { events: [DOMObserver.ADD], timeout: 50 })).rejects.toThrow(
-						DOMObserverErrors.TIMEOUT
+						TimeoutError
 					)
 				})
 
 				it('Rejects the pending promise when wait() is called again', async () => {
 					const first = instance.wait('#bar', { events: [DOMObserver.ADD] })
 					instance.wait('#baz', { events: [DOMObserver.ADD] })
-					await expect(first).rejects.toThrow(DOMObserverErrors.ABORT)
+					await expect(first).rejects.toThrow(ObservationAbortedError)
 				})
 
 				it('Throws when events array is empty', async () => {
-					await expect(() => instance.wait('#foo', { events: [] })).rejects.toThrow()
+					await expect(() => instance.wait('#foo', { events: [] })).rejects.toThrow(InvalidEventsError)
 				})
 
 				it.each([[-1], [NaN], [Infinity], [-Infinity]])(
-					'Rejects with [TIMEOUT] when timeout is %s',
+					'Rejects with InvalidOptionsError when timeout is %s',
 					async (value) => {
-						await expect(instance.wait('#foo', { timeout: value })).rejects.toThrow(DOMObserverErrors.TIMEOUT)
+						await expect(instance.wait('#foo', { timeout: value })).rejects.toThrow(InvalidOptionsError)
 					}
 				)
 
-				it('Rejects with [TARGET] error when selector is invalid', async () => {
-					await expect(instance.wait('##invalid')).rejects.toThrow(DOMObserverErrors.TARGET)
+				it('Rejects with InvalidTargetError when selector is invalid', async () => {
+					await expect(instance.wait('##invalid')).rejects.toThrow(InvalidTargetError)
 				})
 
-				it('Rejects with [TARGET] error when root selector is invalid', async () => {
-					await expect(instance.wait('#foo', { root: '##invalid' })).rejects.toThrow(DOMObserverErrors.TARGET)
+				it('Rejects with InvalidTargetError when root selector is invalid', async () => {
+					await expect(instance.wait('#foo', { root: '##invalid' })).rejects.toThrow(InvalidTargetError)
 				})
 
 				it('Rejects immediately when signal is already aborted', async () => {
@@ -200,7 +208,7 @@ describe('DOMObserver', () => {
 					}, 30)
 					await expect(
 						instance.wait('button', { events: [DOMObserver.ADD], filter: () => false, timeout: 80 })
-					).rejects.toThrow(DOMObserverErrors.TIMEOUT)
+					).rejects.toThrow(TimeoutError)
 				})
 
 				it('Skips EXIST when filter returns false and resolves on next matching mutation', async () => {
@@ -289,14 +297,14 @@ describe('DOMObserver', () => {
 				expect(target).toBe('#second-wins')
 			})
 
-			it('Rejects with [TARGET] when any target selector is invalid', async () => {
-				await expect(instance.wait(['#foo', '##invalid'])).rejects.toThrow(DOMObserverErrors.TARGET)
+			it('Rejects with InvalidTargetError when any target selector is invalid', async () => {
+				await expect(instance.wait(['#foo', '##invalid'])).rejects.toThrow(InvalidTargetError)
 			})
 
-			it('Rejects with [TIMEOUT] when no target matches within the time limit', async () => {
+			it('Rejects with TimeoutError when no target matches within the time limit', async () => {
 				await expect(
 					instance.wait(['#missing1', '#missing2'], { events: [DOMObserver.ADD], timeout: 50 })
-				).rejects.toThrow(DOMObserverErrors.TIMEOUT)
+				).rejects.toThrow(TimeoutError)
 			})
 
 			it('Rejects with AbortError when signal is aborted during multi-target observation', async () => {
@@ -474,8 +482,8 @@ describe('DOMObserver', () => {
 				root.remove()
 			})
 
-			it('Throws with [TARGET] error when root selector is invalid', () => {
-				expect(() => instance.watch('#foo', onEvent, { root: '##invalid' })).toThrow(DOMObserverErrors.TARGET)
+			it('Throws InvalidTargetError when root selector is invalid', () => {
+				expect(() => instance.watch('#foo', onEvent, { root: '##invalid' })).toThrow(InvalidTargetError)
 			})
 
 			it('Respects root when observing CHANGE on an Element reference', async () => {
@@ -556,24 +564,24 @@ describe('DOMObserver', () => {
 			})
 
 			it('Throws when events array is empty', () => {
-				expect(() => instance.watch('#foo', onEvent, { events: [] })).toThrow(DOMObserverErrors.EVENTS)
+				expect(() => instance.watch('#foo', onEvent, { events: [] })).toThrow(InvalidEventsError)
 			})
 
 			it.each([[-1], [NaN], [Infinity], [-Infinity]])(
-				'Throws with [TIMEOUT] when timeout is %s',
+				'Throws InvalidOptionsError when timeout is %s',
 				(value) => {
-					expect(() => instance.watch('#foo', onEvent, { timeout: value })).toThrow(DOMObserverErrors.TIMEOUT)
+					expect(() => instance.watch('#foo', onEvent, { timeout: value })).toThrow(InvalidOptionsError)
 				}
 			)
 
-			it('Throws with [TARGET] error when selector is invalid', () => {
-				expect(() => instance.watch('##invalid', onEvent)).toThrow(DOMObserverErrors.TARGET)
+			it('Throws InvalidTargetError when selector is invalid', () => {
+				expect(() => instance.watch('##invalid', onEvent)).toThrow(InvalidTargetError)
 			})
 
 			it('Rejects the pending wait() promise when watch() is called', async () => {
 				const pending = instance.wait('#bar', { events: [DOMObserver.ADD] })
 				instance.watch('#foo', onEvent)
-				await expect(pending).rejects.toThrow(DOMObserverErrors.ABORT)
+				await expect(pending).rejects.toThrow(ObservationAbortedError)
 			})
 
 			it('Returns the instance for chaining', () => {
@@ -607,7 +615,7 @@ describe('DOMObserver', () => {
 				await _sleep(100)
 				expect(onEvent).not.toHaveBeenCalled()
 				expect(onError).toHaveBeenCalledOnce()
-				expect((onError.mock.calls[0][0] as Error).message).toMatch(DOMObserverErrors.TIMEOUT)
+				expect(onError.mock.calls[0][0]).toBeInstanceOf(TimeoutError)
 			})
 
 			it('Does not call onError when a mutation occurs before timeout', async () => {
@@ -716,11 +724,44 @@ describe('DOMObserver', () => {
 	})
 })
 
-describe('DOMObserverErrors', () => {
-	it('Exports expected error code values', () => {
-		expect(DOMObserverErrors.TIMEOUT).toBe('[TIMEOUT]')
-		expect(DOMObserverErrors.ABORT).toBe('[ABORT]')
-		expect(DOMObserverErrors.EVENTS).toBe('[EVENTS]')
-		expect(DOMObserverErrors.TARGET).toBe('[TARGET]')
+describe('Error classes', () => {
+	it('TimeoutError exposes target and timeout properties', () => {
+		const err = new TimeoutError('#foo', 500)
+		expect(err).toBeInstanceOf(TimeoutError)
+		expect(err.name).toBe('TimeoutError')
+		expect(err.target).toBe('#foo')
+		expect(err.timeout).toBe(500)
+	})
+
+	it('TimeoutError handles array targets', () => {
+		const err = new TimeoutError(['#a', '#b'], 200)
+		expect(err.target).toEqual(['#a', '#b'])
+	})
+
+	it('ObservationAbortedError has correct name', () => {
+		const err = new ObservationAbortedError('test reason')
+		expect(err).toBeInstanceOf(ObservationAbortedError)
+		expect(err.name).toBe('ObservationAbortedError')
+		expect(err.message).toBe('test reason')
+	})
+
+	it('InvalidEventsError has correct name', () => {
+		const err = new InvalidEventsError()
+		expect(err).toBeInstanceOf(InvalidEventsError)
+		expect(err.name).toBe('InvalidEventsError')
+	})
+
+	it('InvalidTargetError exposes selector property', () => {
+		const err = new InvalidTargetError('##bad')
+		expect(err).toBeInstanceOf(InvalidTargetError)
+		expect(err.name).toBe('InvalidTargetError')
+		expect(err.selector).toBe('##bad')
+	})
+
+	it('InvalidOptionsError has correct name', () => {
+		const err = new InvalidOptionsError('timeout must be positive')
+		expect(err).toBeInstanceOf(InvalidOptionsError)
+		expect(err.name).toBe('InvalidOptionsError')
+		expect(err.message).toBe('timeout must be positive')
 	})
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,4 +9,11 @@ export type {
 	WatchOptions,
 } from './DOMObserver'
 export { default as DOMObserver } from './DOMObserver'
-export { InvalidEventsError, InvalidOptionsError, InvalidTargetError, ObservationAbortedError, TimeoutError } from './DOMObserverErrors'
+export {
+	InvalidEventsError,
+	InvalidOptionsError,
+	InvalidTargetError,
+	InvalidTimeoutError,
+	ObservationAbortedError,
+	TimeoutError,
+} from './DOMObserverErrors'

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,5 +9,4 @@ export type {
 	WatchOptions,
 } from './DOMObserver'
 export { default as DOMObserver } from './DOMObserver'
-export type { DOMObserverErrorCode } from './DOMObserverErrors'
-export { DOMObserverErrors } from './DOMObserverErrors'
+export { InvalidEventsError, InvalidOptionsError, InvalidTargetError, ObservationAbortedError, TimeoutError } from './DOMObserverErrors'

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,2 @@
+/** A CSS selector string or a direct DOM Element reference used to identify the observed target. */
+export type DOMTarget = Element | string

--- a/src/utils/resolveDOMTarget.ts
+++ b/src/utils/resolveDOMTarget.ts
@@ -1,4 +1,4 @@
-import type { DOMTarget } from '../DOMObserver'
+import type { DOMTarget } from '../types'
 import { InvalidTargetError } from '../DOMObserverErrors'
 import isElement from './isElement'
 

--- a/src/utils/resolveDOMTarget.ts
+++ b/src/utils/resolveDOMTarget.ts
@@ -1,5 +1,5 @@
 import type { DOMTarget } from '../DOMObserver'
-import { DOMObserverErrors } from '../DOMObserverErrors'
+import { InvalidTargetError } from '../DOMObserverErrors'
 import isElement from './isElement'
 
 const resolveDOMTarget = (target: DOMTarget | undefined): Element | null => {
@@ -8,7 +8,7 @@ const resolveDOMTarget = (target: DOMTarget | undefined): Element | null => {
 	try {
 		return document.querySelector(target as string)
 	} catch {
-		throw new Error(`${DOMObserverErrors.TARGET}: "${target}" is not a valid CSS selector`)
+		throw new InvalidTargetError(target as string)
 	}
 }
 


### PR DESCRIPTION
## Summary

Replaces the `DOMObserverErrors` constant object and plain `Error` throws with five dedicated `Error` subclasses, enabling `instanceof` checks and structured error inspection. Consumers no longer need fragile `message.includes('[X]')` string matching.

## Changes

- `src/DOMObserverErrors.ts` — new file: `TimeoutError`, `ObservationAbortedError`, `InvalidEventsError`, `InvalidTargetError`, `InvalidOptionsError`; `DOMObserverErrors` and `DOMObserverErrorCode` removed
- `src/DOMObserver.ts` — all `new Error(DOMObserverErrors.X + ...)` replaced with typed instances; JSDoc `@throws` updated
- `src/utils/resolveDOMTarget.ts` — throws `InvalidTargetError` instead of plain `Error`
- `src/index.ts` — exports the five new classes; `DOMObserverErrors`/`DOMObserverErrorCode` removed
- `src/__tests__/DOMObserver.test.ts` — all `.toThrow(DOMObserverErrors.X)` migrated to class-based assertions; new `describe('Error classes')` block with structural property tests
- `README.md` — "Error constants" section replaced by "Error classes" with `instanceof` examples and property table

## ⚠️ Breaking changes

- **`DOMObserverErrors`** and **`DOMObserverErrorCode`** are removed from exports
- Error messages no longer carry `[TIMEOUT]`/`[ABORT]`/`[EVENTS]`/`[TARGET]` prefixes
- Migration table:

| Before | After |
|---|---|
| `e.message.includes('[TIMEOUT]')` | `e instanceof TimeoutError` |
| `e.message.includes('[ABORT]')` | `e instanceof ObservationAbortedError` |
| `e.message.includes('[EVENTS]')` | `e instanceof InvalidEventsError` |
| `e.message.includes('[TARGET]')` | `e instanceof InvalidTargetError` |
| `e.message.includes('[TIMEOUT]')` (invalid option) | `e instanceof InvalidOptionsError` |

The `AbortSignal` rejection path (`DOMException` with `name: 'AbortError'`) is unchanged.

## Test plan

- [x] `tsc --noEmit` passes
- [x] All 86 tests pass (`vitest run`)
- [x] 100% statement/function/line coverage
- [x] `TimeoutError.target` and `.timeout` properties verified
- [x] `InvalidTargetError.selector` property verified
- [x] All five classes verified for correct `name` and `instanceof`

Closes #51