### PR TITLE
feat(watch)!: Change callback signature to single payload object

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@ import { DOMObserver } from '@untemps/dom-observer'
 
 // Track every attribute change on an element
 const observer = new DOMObserver()
-observer.watch('#foo', (node, event, { attributeName, oldValue } = {}) => {
+observer.watch('#foo', ({ node, options: { attributeName, oldValue } = {} }) => {
 	console.log(`${attributeName} changed from ${oldValue} to ${node.getAttribute(attributeName)}`)
 }, { events: [DOMObserver.CHANGE] })
 
 // React to every matching node added or removed
 const listObserver = new DOMObserver()
-listObserver.watch('.list-item', (node, event) => {
+listObserver.watch('.list-item', ({ node, event }) => {
 	if (event === DOMObserver.ADD) console.log(`Item added: ${node.textContent}`)
 	if (event === DOMObserver.REMOVE) console.log(`Item removed: ${node.textContent}`)
 }, { events: [DOMObserver.ADD, DOMObserver.REMOVE] })
@@ -55,7 +55,7 @@ Unlike `wait`, `watch` does not return a Promise. It returns `this`, allowing me
 Pass `once: true` to stop the observation automatically after the first matching event, without needing to call `clear()` manually:
 
 ```javascript
-observer.watch('#foo', (node, event) => {
+observer.watch('#foo', ({ node }) => {
 	doSomething(node)  // called exactly once
 }, { events: [DOMObserver.ADD], once: true })
 ```
@@ -63,7 +63,7 @@ observer.watch('#foo', (node, event) => {
 Pass `debounce` to delay the callback until mutations have stopped for a given number of milliseconds — useful when you only care about the final state after a burst of rapid changes:
 
 ```javascript
-observer.watch('#progress', (node) => {
+observer.watch('#progress', ({ node }) => {
 	console.log('final value:', node.getAttribute('data-value'))
 }, {
 	events: [DOMObserver.CHANGE],
@@ -76,7 +76,7 @@ Pass a `timeout` to automatically stop the observation if no matching mutation o
 
 ```javascript
 const observer = new DOMObserver()
-observer.watch('#foo', (node, event) => {
+observer.watch('#foo', ({ node, event }) => {
 	console.log(`Event: ${event}`)
 }, {
 	events: [DOMObserver.ADD],
@@ -100,7 +100,7 @@ observer.watch('#foo', (node, event) => {
 | - `once`            | Boolean           | When `true`, automatically calls `clear()` after the first matching event. Defaults to `false`.                                                          |
 | - `debounce`        | Number            | Milliseconds to wait after the last mutation before invoking the callback. The callback receives the last mutation's arguments. `0` disables debouncing. |
 | - `root`            | Element or String | DOM element or CSS selector to use as the observation root. Only mutations within this subtree are observed. Defaults to `document.documentElement`.     |
-| - `filter`          | Function          | `(node, event, options?) => boolean`. Called before invoking the callback. Return `false` to skip the event and keep observing.                           |
+| - `filter`          | Function          | `({ node, event, options? }) => boolean`. Called before invoking the callback. Return `false` to skip the event and keep observing.                           |
 
 #### `onEvent` callback arguments
 
@@ -169,7 +169,7 @@ Calling `clear()` after `wait()` resolves is safe and is a no-op. If a `timeout`
 | - `attributeFilter` | Array             | List of attribute names to observe (DOMObserver.CHANGE event only)                                                                                       |
 | - `signal`          | AbortSignal       | An `AbortSignal` to cancel the observation. If already aborted, the Promise rejects immediately with an `AbortError`.                                    |
 | - `root`            | Element or String | DOM element or CSS selector to use as the observation root. Only mutations within this subtree are observed. Defaults to `document.documentElement`.     |
-| - `filter`          | Function          | `(node, event, options?) => boolean`. Called before resolving the Promise. Return `false` to skip the event and keep waiting.                             |
+| - `filter`          | Function          | `({ node, event, options? }) => boolean`. Called before resolving the Promise. Return `false` to skip the event and keep waiting.                             |
 
 #### Resolved value
 
@@ -207,7 +207,7 @@ The `isObserving` getter returns `true` when an observation is currently active:
 
 ```javascript
 const observer = new DOMObserver()
-observer.watch('#foo', (node, event) => { /* ... */ })
+observer.watch('#foo', ({ node, event }) => { /* ... */ })
 console.log(observer.isObserving) // true
 observer.clear()
 console.log(observer.isObserving) // false
@@ -275,7 +275,7 @@ const onError = (err) => console.error(err.message)
 const observer = new DOMObserver()
 observer.watch(
     '.foo',
-    (node, event, { attributeName } = {}) => {
+    ({ node, event, options: { attributeName } = {} }) => {
         switch (event) {
             case DOMObserver.EXIST: {
                 console.log('Element ' + node.id + ' exists already')

--- a/dev/src/index.js
+++ b/dev/src/index.js
@@ -27,7 +27,7 @@ addButton.addEventListener('click', () => {
 	}
 })
 
-const onEvent = (node, event, { attributeName } = {}) => {
+const onEvent = ({ node, event, options: { attributeName } = {} }) => {
 	switch (event) {
 		case DOMObserver.ADD: {
 			log(`[ADD]\t\tElement id: ${node.id}`)

--- a/src/DOMObserver.ts
+++ b/src/DOMObserver.ts
@@ -40,13 +40,7 @@ export type OnEventCallback = (payload: EventPayload) => void
 export type FilterCallback = (payload: EventPayload) => boolean
 
 /** Resolved value of the Promise returned by `wait()`. */
-export interface WaitResult {
-	/** The matching DOM element. */
-	node: Element
-	/** The event type that caused the Promise to settle. */
-	event: DOMObserverEvent
-	/** Additional mutation metadata, present only for `CHANGE` events. */
-	options?: ChangeOptions
+export interface WaitResult extends EventPayload {
 	/** The target entry that triggered the match. Only populated when `wait()` was called with an array of targets. */
 	target?: DOMTarget
 }
@@ -195,7 +189,7 @@ class DOMObserver {
 			// onMatch always fires synchronously before fireCallback in _observe, so matchedTarget
 			// is guaranteed to be set before callback runs.
 			const callback: OnEventCallback = ({ node, event, options }) => {
-				const result: WaitResult = options ? { node, event, options } : { node, event }
+				const result: WaitResult = { node, event, options }
 				if (isMulti) result.target = matchedTarget
 				settle(result)
 			}
@@ -333,7 +327,7 @@ class DOMObserver {
 		const defaultRoot = resolveDOMTarget(root) ?? document.documentElement
 
 		const fireCallback = (node: Element, event: DOMObserverEvent, opts?: ChangeOptions) => {
-			const payload: EventPayload = opts !== undefined ? { node, event, options: opts } : { node, event }
+			const payload: EventPayload = { node, event, options: opts }
 			if (filter && !filter(payload)) return
 			callback(payload)
 		}

--- a/src/DOMObserver.ts
+++ b/src/DOMObserver.ts
@@ -16,20 +16,28 @@ export interface ChangeOptions {
 	oldValue: string | null
 }
 
+/** Payload delivered to `OnEventCallback` and `FilterCallback`. */
+export interface EventPayload {
+	/** The matching DOM element. */
+	node: Element
+	/** The event type that fired. */
+	event: DOMObserverEvent
+	/** Additional mutation metadata, present only for `CHANGE` events. */
+	options?: ChangeOptions
+}
+
 /**
  * Callback invoked by `watch()` whenever an observed event occurs.
  *
- * @param node - The matching DOM element.
- * @param event - The event type that fired.
- * @param options - Additional mutation metadata, present only for `CHANGE` events.
+ * @param payload - Object containing `node`, `event`, and optional `options`.
  */
-export type OnEventCallback = (node: Element, event: DOMObserverEvent, options?: ChangeOptions) => void
+export type OnEventCallback = (payload: EventPayload) => void
 
 /**
  * Predicate called before invoking the event callback. Return `true` to let the event through,
- * `false` to skip it. Receives the same arguments as `OnEventCallback`.
+ * `false` to skip it. Receives the same payload as `OnEventCallback`.
  */
-export type FilterCallback = (node: Element, event: DOMObserverEvent, options?: ChangeOptions) => boolean
+export type FilterCallback = (payload: EventPayload) => boolean
 
 /** Resolved value of the Promise returned by `wait()`. */
 export interface WaitResult {
@@ -186,7 +194,7 @@ class DOMObserver {
 
 			// onMatch always fires synchronously before fireCallback in _observe, so matchedTarget
 			// is guaranteed to be set before callback runs.
-			const callback: OnEventCallback = (node, event, options) => {
+			const callback: OnEventCallback = ({ node, event, options }) => {
 				const result: WaitResult = options ? { node, event, options } : { node, event }
 				if (isMulti) result.target = matchedTarget
 				settle(result)
@@ -275,9 +283,9 @@ class DOMObserver {
 		let callback: OnEventCallback = onEvent
 		if (timeout > 0) {
 			const wrapped = callback
-			callback = (...args) => {
+			callback = (payload) => {
 				clearTimeout(this._timeout)
-				wrapped(...args)
+				wrapped(payload)
 			}
 			this._timeout = setTimeout(() => {
 				this.clear()
@@ -286,16 +294,16 @@ class DOMObserver {
 		}
 		if (debounce > 0) {
 			const wrapped = callback
-			callback = (...args) => {
+			callback = (payload) => {
 				clearTimeout(this._debounceTimer)
-				this._debounceTimer = setTimeout(() => wrapped(...args), debounce)
+				this._debounceTimer = setTimeout(() => wrapped(payload), debounce)
 			}
 		}
 		if (once) {
 			const wrapped = callback
-			callback = (...args) => {
+			callback = (payload) => {
 				this.clear()
-				wrapped(...args)
+				wrapped(payload)
 			}
 		}
 
@@ -325,8 +333,9 @@ class DOMObserver {
 		const defaultRoot = resolveDOMTarget(root) ?? document.documentElement
 
 		const fireCallback = (node: Element, event: DOMObserverEvent, opts?: ChangeOptions) => {
-			if (filter && !filter(node, event, opts)) return
-			opts !== undefined ? callback(node, event, opts) : callback(node, event)
+			const payload: EventPayload = opts !== undefined ? { node, event, options: opts } : { node, event }
+			if (filter && !filter(payload)) return
+			callback(payload)
 		}
 
 		const nodeMatchesTarget = (node: Node, t: DOMTarget): boolean =>

--- a/src/DOMObserver.ts
+++ b/src/DOMObserver.ts
@@ -189,7 +189,7 @@ class DOMObserver {
 			// onMatch always fires synchronously before fireCallback in _observe, so matchedTarget
 			// is guaranteed to be set before callback runs.
 			const callback: OnEventCallback = ({ node, event, options }) => {
-				const result: WaitResult = { node, event, options }
+				const result: WaitResult = options !== undefined ? { node, event, options } : { node, event }
 				if (isMulti) result.target = matchedTarget
 				settle(result)
 			}
@@ -327,7 +327,7 @@ class DOMObserver {
 		const defaultRoot = resolveDOMTarget(root) ?? document.documentElement
 
 		const fireCallback = (node: Element, event: DOMObserverEvent, opts?: ChangeOptions) => {
-			const payload: EventPayload = { node, event, options: opts }
+			const payload: EventPayload = opts !== undefined ? { node, event, options: opts } : { node, event }
 			if (filter && !filter(payload)) return
 			callback(payload)
 		}

--- a/src/__tests__/DOMObserver.test.ts
+++ b/src/__tests__/DOMObserver.test.ts
@@ -230,10 +230,14 @@ describe('DOMObserver', () => {
 					const filter = vi.fn(() => true)
 					setTimeout(() => _modifyElement('#foo', 'class', 'updated'), 50)
 					await instance.wait('#foo', { events: [DOMObserver.CHANGE], filter })
-					expect(filter).toHaveBeenCalledWith({ node: el, event: DOMObserver.CHANGE, options: {
-						attributeName: 'class',
-						oldValue: 'bar',
-					} })
+					expect(filter).toHaveBeenCalledWith({
+						node: el,
+						event: DOMObserver.CHANGE,
+						options: {
+							attributeName: 'class',
+							oldValue: 'bar',
+						},
+					})
 				})
 
 				it('Leaves result.target undefined for a single-target call', async () => {
@@ -394,14 +398,22 @@ describe('DOMObserver', () => {
 				_modifyElement('#foo', 'class', 'change2')
 				await _sleep()
 				expect(onEvent).toHaveBeenCalledTimes(2)
-				expect(onEvent).toHaveBeenNthCalledWith(1, { node: el, event: DOMObserver.CHANGE, options: {
-					attributeName: 'class',
-					oldValue: 'bar',
-				} })
-				expect(onEvent).toHaveBeenNthCalledWith(2, { node: el, event: DOMObserver.CHANGE, options: {
-					attributeName: 'class',
-					oldValue: 'change1',
-				} })
+				expect(onEvent).toHaveBeenNthCalledWith(1, {
+					node: el,
+					event: DOMObserver.CHANGE,
+					options: {
+						attributeName: 'class',
+						oldValue: 'bar',
+					},
+				})
+				expect(onEvent).toHaveBeenNthCalledWith(2, {
+					node: el,
+					event: DOMObserver.CHANGE,
+					options: {
+						attributeName: 'class',
+						oldValue: 'change1',
+					},
+				})
 			})
 
 			it('Triggers onEvent for each matching added and removed node', async () => {
@@ -427,8 +439,16 @@ describe('DOMObserver', () => {
 				b.setAttribute('data-x', '2')
 				await _sleep()
 				expect(onEvent).toHaveBeenCalledTimes(2)
-				expect(onEvent).toHaveBeenCalledWith({ node: a, event: DOMObserver.CHANGE, options: { attributeName: 'data-x', oldValue: null } })
-				expect(onEvent).toHaveBeenCalledWith({ node: b, event: DOMObserver.CHANGE, options: { attributeName: 'data-x', oldValue: null } })
+				expect(onEvent).toHaveBeenCalledWith({
+					node: a,
+					event: DOMObserver.CHANGE,
+					options: { attributeName: 'data-x', oldValue: null },
+				})
+				expect(onEvent).toHaveBeenCalledWith({
+					node: b,
+					event: DOMObserver.CHANGE,
+					options: { attributeName: 'data-x', oldValue: null },
+				})
 			})
 
 			it('Only fires for attributes in the filter list', async () => {
@@ -441,10 +461,14 @@ describe('DOMObserver', () => {
 				_modifyElement('#foo', 'data-watched', 'y')
 				await _sleep()
 				expect(onEvent).toHaveBeenCalledOnce()
-				expect(onEvent).toHaveBeenCalledWith({ node: el, event: DOMObserver.CHANGE, options: {
-					attributeName: 'data-watched',
-					oldValue: null,
-				} })
+				expect(onEvent).toHaveBeenCalledWith({
+					node: el,
+					event: DOMObserver.CHANGE,
+					options: {
+						attributeName: 'data-watched',
+						oldValue: null,
+					},
+				})
 			})
 
 			it('Only fires for mutations within the root element', async () => {
@@ -531,7 +555,11 @@ describe('DOMObserver', () => {
 				instance.watch('#foo', onEvent, { events: [DOMObserver.CHANGE], filter })
 				_modifyElement('#foo', 'class', 'updated')
 				await _sleep()
-				expect(filter).toHaveBeenCalledWith({ node: el, event: DOMObserver.CHANGE, options: { attributeName: 'class', oldValue: 'bar' } })
+				expect(filter).toHaveBeenCalledWith({
+					node: el,
+					event: DOMObserver.CHANGE,
+					options: { attributeName: 'class', oldValue: 'bar' },
+				})
 			})
 
 			it('Does not fire for ADD events rejected by filter', async () => {
@@ -680,10 +708,14 @@ describe('DOMObserver', () => {
 				_modifyElement('#foo', 'class', 'change1')
 				_modifyElement('#foo', 'class', 'change2')
 				await _sleep(150)
-				expect(onEvent).toHaveBeenCalledWith({ node: el, event: DOMObserver.CHANGE, options: {
-					attributeName: 'class',
-					oldValue: 'change1',
-				} })
+				expect(onEvent).toHaveBeenCalledWith({
+					node: el,
+					event: DOMObserver.CHANGE,
+					options: {
+						attributeName: 'class',
+						oldValue: 'change1',
+					},
+				})
 			})
 
 			it('Does not fire onEvent when clear() is called during the debounce period', async () => {

--- a/src/__tests__/DOMObserver.test.ts
+++ b/src/__tests__/DOMObserver.test.ts
@@ -36,8 +36,8 @@ describe('DOMObserver', () => {
 				})
 
 				it('Observes an element to be added', async () => {
-					const { node: found, event } = await instance.wait('#foo')
-					expect(found).toEqual(node)
+					const { node: foundNode, event } = await instance.wait('#foo')
+					expect(foundNode).toEqual(node)
 					expect(event).toBe(DOMObserver.EXIST)
 				})
 
@@ -45,8 +45,8 @@ describe('DOMObserver', () => {
 					setTimeout(() => {
 						_removeElement('#foo')
 					}, 100)
-					const { node: found, event } = await instance.wait('#foo', { events: [DOMObserver.REMOVE] })
-					expect(found).toEqual(node)
+					const { node: foundNode, event } = await instance.wait('#foo', { events: [DOMObserver.REMOVE] })
+					expect(foundNode).toEqual(node)
 					expect(event).toBe(DOMObserver.REMOVE)
 				})
 
@@ -55,13 +55,13 @@ describe('DOMObserver', () => {
 						_modifyElement('#foo', 'class', 'gag')
 					}, 100)
 					const {
-						node: found,
+						node: foundNode,
 						event,
 						options: { attributeName, oldValue } = {},
 					} = await instance.wait('#foo', {
 						events: [DOMObserver.CHANGE],
 					})
-					expect(found).toEqual(node)
+					expect(foundNode).toEqual(node)
 					expect(event).toBe(DOMObserver.CHANGE)
 					expect(attributeName).toBe('class')
 					expect(oldValue).toBe('bar')
@@ -184,8 +184,8 @@ describe('DOMObserver', () => {
 				})
 
 				it('Resolves immediately when filter passes for an existing element', async () => {
-					const { node: found, event } = await instance.wait('#foo', { filter: () => true })
-					expect(found).toEqual(node)
+					const { node: foundNode, event } = await instance.wait('#foo', { filter: () => true })
+					expect(foundNode).toEqual(node)
 					expect(event).toBe(DOMObserver.EXIST)
 				})
 
@@ -251,8 +251,8 @@ describe('DOMObserver', () => {
 					setTimeout(() => {
 						node = _createElement('foo')
 					}, 100)
-					const { node: found, event } = await instance.wait('#foo')
-					expect(found).toEqual(node)
+					const { node: foundNode, event } = await instance.wait('#foo')
+					expect(foundNode).toEqual(node)
 					expect(event).toBe(DOMObserver.ADD)
 				})
 			})
@@ -264,8 +264,8 @@ describe('DOMObserver', () => {
 			})
 
 			it('Resolves on EXIST for the first target found in the DOM', async () => {
-				const { node: found, event, target } = await instance.wait(['#foo', '#bar'])
-				expect(found).toEqual(node)
+				const { node: foundNode, event, target } = await instance.wait(['#foo', '#bar'])
+				expect(foundNode).toEqual(node)
 				expect(event).toBe(DOMObserver.EXIST)
 				expect(target).toBe('#foo')
 			})
@@ -516,15 +516,15 @@ describe('DOMObserver', () => {
 			it('Respects root when observing CHANGE on an Element reference', async () => {
 				const root = document.createElement('div')
 				document.body.appendChild(root)
-				const watched = document.createElement('div')
-				root.appendChild(watched)
+				const watchedNode = document.createElement('div')
+				root.appendChild(watchedNode)
 				const outside = document.createElement('div')
 				document.body.appendChild(outside)
-				instance.watch(watched, onEvent, { events: [DOMObserver.CHANGE], root })
+				instance.watch(watchedNode, onEvent, { events: [DOMObserver.CHANGE], root })
 				outside.setAttribute('data-x', '1')
 				await _sleep()
 				expect(onEvent).not.toHaveBeenCalled()
-				watched.setAttribute('data-x', '1')
+				watchedNode.setAttribute('data-x', '1')
 				await _sleep()
 				expect(onEvent).toHaveBeenCalledOnce()
 				outside.remove()

--- a/src/__tests__/DOMObserver.test.ts
+++ b/src/__tests__/DOMObserver.test.ts
@@ -2,8 +2,8 @@ import {
 	DOMObserver,
 	InvalidEventsError,
 	InvalidOptionsError,
-	InvalidTimeoutError,
 	InvalidTargetError,
+	InvalidTimeoutError,
 	ObservationAbortedError,
 	type OnEventCallback,
 	TimeoutError,
@@ -200,7 +200,7 @@ describe('DOMObserver', () => {
 					}, 100)
 					const { node } = await instance.wait('button', {
 						events: [DOMObserver.ADD],
-						filter: (n) => n.classList.contains('primary'),
+						filter: ({ node }) => node.classList.contains('primary'),
 					})
 					expect(node.classList.contains('primary')).toBe(true)
 				})
@@ -220,7 +220,7 @@ describe('DOMObserver', () => {
 					setTimeout(() => btn.setAttribute('data-ready', 'true'), 50)
 					const { node } = await instance.wait('button', {
 						events: [DOMObserver.EXIST, DOMObserver.CHANGE],
-						filter: (n) => n.hasAttribute('data-ready'),
+						filter: ({ node }) => node.hasAttribute('data-ready'),
 					})
 					expect(node.getAttribute('data-ready')).toBe('true')
 					btn.remove()
@@ -230,10 +230,10 @@ describe('DOMObserver', () => {
 					const filter = vi.fn(() => true)
 					setTimeout(() => _modifyElement('#foo', 'class', 'updated'), 50)
 					await instance.wait('#foo', { events: [DOMObserver.CHANGE], filter })
-					expect(filter).toHaveBeenCalledWith(el, DOMObserver.CHANGE, {
+					expect(filter).toHaveBeenCalledWith({ node: el, event: DOMObserver.CHANGE, options: {
 						attributeName: 'class',
 						oldValue: 'bar',
-					})
+					} })
 				})
 
 				it('Leaves result.target undefined for a single-target call', async () => {
@@ -355,7 +355,7 @@ describe('DOMObserver', () => {
 				}, 50)
 				const { node, target } = await instance.wait(['#filtered-a', '#filtered-b'], {
 					events: [DOMObserver.ADD],
-					filter: (node) => {
+					filter: ({ node }) => {
 						callCount++
 						return node.id === 'filtered-b'
 					},
@@ -379,12 +379,12 @@ describe('DOMObserver', () => {
 
 			it('Triggers onEvent immediately with EXIST when element is present', () => {
 				instance.watch('#foo', onEvent)
-				expect(onEvent).toHaveBeenCalledWith(el, DOMObserver.EXIST)
+				expect(onEvent).toHaveBeenCalledWith({ node: el, event: DOMObserver.EXIST })
 			})
 
 			it('Accepts an Element reference as target', () => {
 				instance.watch(el, onEvent)
-				expect(onEvent).toHaveBeenCalledWith(el, DOMObserver.EXIST)
+				expect(onEvent).toHaveBeenCalledWith({ node: el, event: DOMObserver.EXIST })
 			})
 
 			it('Triggers onEvent on every successive attribute change', async () => {
@@ -394,14 +394,14 @@ describe('DOMObserver', () => {
 				_modifyElement('#foo', 'class', 'change2')
 				await _sleep()
 				expect(onEvent).toHaveBeenCalledTimes(2)
-				expect(onEvent).toHaveBeenNthCalledWith(1, el, DOMObserver.CHANGE, {
+				expect(onEvent).toHaveBeenNthCalledWith(1, { node: el, event: DOMObserver.CHANGE, options: {
 					attributeName: 'class',
 					oldValue: 'bar',
-				})
-				expect(onEvent).toHaveBeenNthCalledWith(2, el, DOMObserver.CHANGE, {
+				} })
+				expect(onEvent).toHaveBeenNthCalledWith(2, { node: el, event: DOMObserver.CHANGE, options: {
 					attributeName: 'class',
 					oldValue: 'change1',
-				})
+				} })
 			})
 
 			it('Triggers onEvent for each matching added and removed node', async () => {
@@ -410,11 +410,11 @@ describe('DOMObserver', () => {
 				const b = _createElementWithClass('item')
 				await _sleep()
 				expect(onEvent).toHaveBeenCalledTimes(2)
-				expect(onEvent).toHaveBeenCalledWith(a, DOMObserver.ADD)
-				expect(onEvent).toHaveBeenCalledWith(b, DOMObserver.ADD)
+				expect(onEvent).toHaveBeenCalledWith({ node: a, event: DOMObserver.ADD })
+				expect(onEvent).toHaveBeenCalledWith({ node: b, event: DOMObserver.ADD })
 				document.body.removeChild(a)
 				await _sleep()
-				expect(onEvent).toHaveBeenCalledWith(a, DOMObserver.REMOVE)
+				expect(onEvent).toHaveBeenCalledWith({ node: a, event: DOMObserver.REMOVE })
 				expect(onEvent).toHaveBeenCalledTimes(3)
 			})
 
@@ -427,8 +427,8 @@ describe('DOMObserver', () => {
 				b.setAttribute('data-x', '2')
 				await _sleep()
 				expect(onEvent).toHaveBeenCalledTimes(2)
-				expect(onEvent).toHaveBeenCalledWith(a, DOMObserver.CHANGE, { attributeName: 'data-x', oldValue: null })
-				expect(onEvent).toHaveBeenCalledWith(b, DOMObserver.CHANGE, { attributeName: 'data-x', oldValue: null })
+				expect(onEvent).toHaveBeenCalledWith({ node: a, event: DOMObserver.CHANGE, options: { attributeName: 'data-x', oldValue: null } })
+				expect(onEvent).toHaveBeenCalledWith({ node: b, event: DOMObserver.CHANGE, options: { attributeName: 'data-x', oldValue: null } })
 			})
 
 			it('Only fires for attributes in the filter list', async () => {
@@ -441,10 +441,10 @@ describe('DOMObserver', () => {
 				_modifyElement('#foo', 'data-watched', 'y')
 				await _sleep()
 				expect(onEvent).toHaveBeenCalledOnce()
-				expect(onEvent).toHaveBeenCalledWith(el, DOMObserver.CHANGE, {
+				expect(onEvent).toHaveBeenCalledWith({ node: el, event: DOMObserver.CHANGE, options: {
 					attributeName: 'data-watched',
 					oldValue: null,
-				})
+				} })
 			})
 
 			it('Only fires for mutations within the root element', async () => {
@@ -531,7 +531,7 @@ describe('DOMObserver', () => {
 				instance.watch('#foo', onEvent, { events: [DOMObserver.CHANGE], filter })
 				_modifyElement('#foo', 'class', 'updated')
 				await _sleep()
-				expect(filter).toHaveBeenCalledWith(el, DOMObserver.CHANGE, { attributeName: 'class', oldValue: 'bar' })
+				expect(filter).toHaveBeenCalledWith({ node: el, event: DOMObserver.CHANGE, options: { attributeName: 'class', oldValue: 'bar' } })
 			})
 
 			it('Does not fire for ADD events rejected by filter', async () => {
@@ -539,7 +539,7 @@ describe('DOMObserver', () => {
 				inside.id = 'allowed'
 				instance.watch('div', onEvent, {
 					events: [DOMObserver.ADD],
-					filter: (n) => n.id === 'allowed',
+					filter: ({ node }) => node.id === 'allowed',
 				})
 				document.body.appendChild(document.createElement('div'))
 				await _sleep()
@@ -680,10 +680,10 @@ describe('DOMObserver', () => {
 				_modifyElement('#foo', 'class', 'change1')
 				_modifyElement('#foo', 'class', 'change2')
 				await _sleep(150)
-				expect(onEvent).toHaveBeenCalledWith(el, DOMObserver.CHANGE, {
+				expect(onEvent).toHaveBeenCalledWith({ node: el, event: DOMObserver.CHANGE, options: {
 					attributeName: 'class',
 					oldValue: 'change1',
-				})
+				} })
 			})
 
 			it('Does not fire onEvent when clear() is called during the debounce period', async () => {
@@ -717,7 +717,7 @@ describe('DOMObserver', () => {
 				instance.watch('#foo', onEvent)
 				el = _createElement('foo')
 				await _sleep()
-				expect(onEvent).toHaveBeenCalledWith(el, DOMObserver.ADD)
+				expect(onEvent).toHaveBeenCalledWith({ node: el, event: DOMObserver.ADD })
 			})
 		})
 	})

--- a/src/__tests__/DOMObserver.test.ts
+++ b/src/__tests__/DOMObserver.test.ts
@@ -11,7 +11,7 @@ import {
 
 describe('DOMObserver', () => {
 	let instance: DOMObserver
-	let el: HTMLElement
+	let node: HTMLElement
 	let onEvent: ReturnType<typeof vi.fn<OnEventCallback>>
 
 	beforeEach(() => {
@@ -32,12 +32,12 @@ describe('DOMObserver', () => {
 		describe('A promise is resolved as soon as an event occurs', () => {
 			describe('Element is already created and mounted in the DOM', () => {
 				beforeEach(() => {
-					el = _createElement('foo')
+					node = _createElement('foo')
 				})
 
 				it('Observes an element to be added', async () => {
-					const { node, event } = await instance.wait('#foo')
-					expect(node).toEqual(el)
+					const { node: found, event } = await instance.wait('#foo')
+					expect(found).toEqual(node)
 					expect(event).toBe(DOMObserver.EXIST)
 				})
 
@@ -45,8 +45,8 @@ describe('DOMObserver', () => {
 					setTimeout(() => {
 						_removeElement('#foo')
 					}, 100)
-					const { node, event } = await instance.wait('#foo', { events: [DOMObserver.REMOVE] })
-					expect(node).toEqual(el)
+					const { node: found, event } = await instance.wait('#foo', { events: [DOMObserver.REMOVE] })
+					expect(found).toEqual(node)
 					expect(event).toBe(DOMObserver.REMOVE)
 				})
 
@@ -55,13 +55,13 @@ describe('DOMObserver', () => {
 						_modifyElement('#foo', 'class', 'gag')
 					}, 100)
 					const {
-						node,
+						node: found,
 						event,
 						options: { attributeName, oldValue } = {},
 					} = await instance.wait('#foo', {
 						events: [DOMObserver.CHANGE],
 					})
-					expect(node).toEqual(el)
+					expect(found).toEqual(node)
 					expect(event).toBe(DOMObserver.CHANGE)
 					expect(attributeName).toBe('class')
 					expect(oldValue).toBe('bar')
@@ -184,8 +184,8 @@ describe('DOMObserver', () => {
 				})
 
 				it('Resolves immediately when filter passes for an existing element', async () => {
-					const { node, event } = await instance.wait('#foo', { filter: () => true })
-					expect(node).toEqual(el)
+					const { node: found, event } = await instance.wait('#foo', { filter: () => true })
+					expect(found).toEqual(node)
 					expect(event).toBe(DOMObserver.EXIST)
 				})
 
@@ -231,7 +231,7 @@ describe('DOMObserver', () => {
 					setTimeout(() => _modifyElement('#foo', 'class', 'updated'), 50)
 					await instance.wait('#foo', { events: [DOMObserver.CHANGE], filter })
 					expect(filter).toHaveBeenCalledWith({
-						node: el,
+						node,
 						event: DOMObserver.CHANGE,
 						options: {
 							attributeName: 'class',
@@ -249,10 +249,10 @@ describe('DOMObserver', () => {
 			describe('Element creation and mounting are delayed', () => {
 				it('Observes an element to be added', async () => {
 					setTimeout(() => {
-						el = _createElement('foo')
+						node = _createElement('foo')
 					}, 100)
-					const { node, event } = await instance.wait('#foo')
-					expect(node).toEqual(el)
+					const { node: found, event } = await instance.wait('#foo')
+					expect(found).toEqual(node)
 					expect(event).toBe(DOMObserver.ADD)
 				})
 			})
@@ -260,12 +260,12 @@ describe('DOMObserver', () => {
 
 		describe('Multiple targets', () => {
 			beforeEach(() => {
-				el = _createElement('foo')
+				node = _createElement('foo')
 			})
 
 			it('Resolves on EXIST for the first target found in the DOM', async () => {
-				const { node, event, target } = await instance.wait(['#foo', '#bar'])
-				expect(node).toEqual(el)
+				const { node: found, event, target } = await instance.wait(['#foo', '#bar'])
+				expect(found).toEqual(node)
 				expect(event).toBe(DOMObserver.EXIST)
 				expect(target).toBe('#foo')
 			})
@@ -378,17 +378,17 @@ describe('DOMObserver', () => {
 
 		describe('Element is already created and mounted in the DOM', () => {
 			beforeEach(() => {
-				el = _createElement('foo')
+				node = _createElement('foo')
 			})
 
 			it('Triggers onEvent immediately with EXIST when element is present', () => {
 				instance.watch('#foo', onEvent)
-				expect(onEvent).toHaveBeenCalledWith({ node: el, event: DOMObserver.EXIST })
+				expect(onEvent).toHaveBeenCalledWith({ node, event: DOMObserver.EXIST })
 			})
 
 			it('Accepts an Element reference as target', () => {
-				instance.watch(el, onEvent)
-				expect(onEvent).toHaveBeenCalledWith({ node: el, event: DOMObserver.EXIST })
+				instance.watch(node, onEvent)
+				expect(onEvent).toHaveBeenCalledWith({ node, event: DOMObserver.EXIST })
 			})
 
 			it('Triggers onEvent on every successive attribute change', async () => {
@@ -399,7 +399,7 @@ describe('DOMObserver', () => {
 				await _sleep()
 				expect(onEvent).toHaveBeenCalledTimes(2)
 				expect(onEvent).toHaveBeenNthCalledWith(1, {
-					node: el,
+					node,
 					event: DOMObserver.CHANGE,
 					options: {
 						attributeName: 'class',
@@ -407,7 +407,7 @@ describe('DOMObserver', () => {
 					},
 				})
 				expect(onEvent).toHaveBeenNthCalledWith(2, {
-					node: el,
+					node,
 					event: DOMObserver.CHANGE,
 					options: {
 						attributeName: 'class',
@@ -418,34 +418,34 @@ describe('DOMObserver', () => {
 
 			it('Triggers onEvent for each matching added and removed node', async () => {
 				instance.watch('.item', onEvent, { events: [DOMObserver.ADD, DOMObserver.REMOVE] })
-				const a = _createElementWithClass('item')
-				const b = _createElementWithClass('item')
+				const nodeA = _createElementWithClass('item')
+				const nodeB = _createElementWithClass('item')
 				await _sleep()
 				expect(onEvent).toHaveBeenCalledTimes(2)
-				expect(onEvent).toHaveBeenCalledWith({ node: a, event: DOMObserver.ADD })
-				expect(onEvent).toHaveBeenCalledWith({ node: b, event: DOMObserver.ADD })
-				document.body.removeChild(a)
+				expect(onEvent).toHaveBeenCalledWith({ node: nodeA, event: DOMObserver.ADD })
+				expect(onEvent).toHaveBeenCalledWith({ node: nodeB, event: DOMObserver.ADD })
+				document.body.removeChild(nodeA)
 				await _sleep()
-				expect(onEvent).toHaveBeenCalledWith({ node: a, event: DOMObserver.REMOVE })
+				expect(onEvent).toHaveBeenCalledWith({ node: nodeA, event: DOMObserver.REMOVE })
 				expect(onEvent).toHaveBeenCalledTimes(3)
 			})
 
 			it('Fires CHANGE for all elements matching a class selector, not just the first', async () => {
-				const a = _createElementWithClass('item')
-				const b = _createElementWithClass('item')
+				const nodeA = _createElementWithClass('item')
+				const nodeB = _createElementWithClass('item')
 				instance.watch('.item', onEvent, { events: [DOMObserver.CHANGE] })
-				a.setAttribute('data-x', '1')
+				nodeA.setAttribute('data-x', '1')
 				await _sleep()
-				b.setAttribute('data-x', '2')
+				nodeB.setAttribute('data-x', '2')
 				await _sleep()
 				expect(onEvent).toHaveBeenCalledTimes(2)
 				expect(onEvent).toHaveBeenCalledWith({
-					node: a,
+					node: nodeA,
 					event: DOMObserver.CHANGE,
 					options: { attributeName: 'data-x', oldValue: null },
 				})
 				expect(onEvent).toHaveBeenCalledWith({
-					node: b,
+					node: nodeB,
 					event: DOMObserver.CHANGE,
 					options: { attributeName: 'data-x', oldValue: null },
 				})
@@ -462,7 +462,7 @@ describe('DOMObserver', () => {
 				await _sleep()
 				expect(onEvent).toHaveBeenCalledOnce()
 				expect(onEvent).toHaveBeenCalledWith({
-					node: el,
+					node,
 					event: DOMObserver.CHANGE,
 					options: {
 						attributeName: 'data-watched',
@@ -516,15 +516,15 @@ describe('DOMObserver', () => {
 			it('Respects root when observing CHANGE on an Element reference', async () => {
 				const root = document.createElement('div')
 				document.body.appendChild(root)
-				const el = document.createElement('div')
-				root.appendChild(el)
+				const watched = document.createElement('div')
+				root.appendChild(watched)
 				const outside = document.createElement('div')
 				document.body.appendChild(outside)
-				instance.watch(el, onEvent, { events: [DOMObserver.CHANGE], root })
+				instance.watch(watched, onEvent, { events: [DOMObserver.CHANGE], root })
 				outside.setAttribute('data-x', '1')
 				await _sleep()
 				expect(onEvent).not.toHaveBeenCalled()
-				el.setAttribute('data-x', '1')
+				watched.setAttribute('data-x', '1')
 				await _sleep()
 				expect(onEvent).toHaveBeenCalledOnce()
 				outside.remove()
@@ -556,7 +556,7 @@ describe('DOMObserver', () => {
 				_modifyElement('#foo', 'class', 'updated')
 				await _sleep()
 				expect(filter).toHaveBeenCalledWith({
-					node: el,
+					node,
 					event: DOMObserver.CHANGE,
 					options: { attributeName: 'class', oldValue: 'bar' },
 				})
@@ -709,7 +709,7 @@ describe('DOMObserver', () => {
 				_modifyElement('#foo', 'class', 'change2')
 				await _sleep(150)
 				expect(onEvent).toHaveBeenCalledWith({
-					node: el,
+					node,
 					event: DOMObserver.CHANGE,
 					options: {
 						attributeName: 'class',
@@ -747,9 +747,9 @@ describe('DOMObserver', () => {
 		describe('Element creation and mounting are delayed', () => {
 			it('Triggers onEvent when element is added', async () => {
 				instance.watch('#foo', onEvent)
-				el = _createElement('foo')
+				node = _createElement('foo')
 				await _sleep()
-				expect(onEvent).toHaveBeenCalledWith({ node: el, event: DOMObserver.ADD })
+				expect(onEvent).toHaveBeenCalledWith({ node, event: DOMObserver.ADD })
 			})
 		})
 	})

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export type {
 	ChangeOptions,
 	DOMObserverEvent,
 	DOMTarget,
+	EventPayload,
 	FilterCallback,
 	OnEventCallback,
 	WaitOptions,


### PR DESCRIPTION
## Summary

Changes `OnEventCallback` and `FilterCallback` from three positional arguments `(node, event, options?)` to a single destructurable `EventPayload` object `({ node, event, options? })`. The new `EventPayload` interface is exported. This mirrors the shape already returned by `wait()` and makes the API extensible without future breaking changes.

## Changes

- `src/DOMObserver.ts` — new `EventPayload` interface; `OnEventCallback` and `FilterCallback` updated; `fireCallback` constructs and passes the payload; `once`/`debounce`/`timeout` wrappers use named `payload` param instead of `...args`; `wait()` internal callback destructures the payload
- `src/index.ts` — exports `EventPayload`
- `src/__tests__/DOMObserver.test.ts` — all `filter` callbacks and `toHaveBeenCalledWith` assertions updated to object form
- `README.md` — all `watch()` examples and filter descriptions updated

## ⚠️ Breaking changes

- **`OnEventCallback`**: `(node, event, options?)` → `({ node, event, options? })`
- **`FilterCallback`**: same change
- Migration is mechanical — wrap existing positional arguments in braces:
  ```diff
  - obs.watch('#foo', (node, event, options) => { ... })
  + obs.watch('#foo', ({ node, event, options }) => { ... })
  ```

## Test plan

- [x] `tsc --noEmit` passes
- [x] All 81 tests pass (`vitest run`)
- [x] 100% statement/function/line coverage
- [x] `onEvent` call argument assertions updated to payload object form
- [x] `filter` call argument assertions updated to payload object form

Closes #52