### PR TITLE
test: Replace TIMEOUT code with TimeoutError in test description

### DIFF
--- a/src/__tests__/DOMObserver.test.ts
+++ b/src/__tests__/DOMObserver.test.ts
@@ -205,7 +205,7 @@ describe('DOMObserver', () => {
 					expect(node.classList.contains('primary')).toBe(true)
 				})
 
-				it('Rejects with TIMEOUT when filter never passes', async () => {
+				it('Rejects with TimeoutError when filter never passes', async () => {
 					setTimeout(() => {
 						document.body.appendChild(document.createElement('button'))
 					}, 30)


### PR DESCRIPTION
## Summary

Replace the remaining hardcoded `TIMEOUT` bracket code in test description with the actual `TimeoutError` class name, consistent with all other error-related descriptions in the test suite.

## Changes

- `src/__tests__/DOMObserver.test.ts` — rename description `'Rejects with TIMEOUT when filter never passes'` → `'Rejects with TimeoutError when filter never passes'`

## Test plan

- [x] All 92 tests pass
- [x] `tsc --noEmit` passes
- [x] 100% coverage maintained

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)