### PR TITLE
feat(events)!: Replace static class properties with exported DOMObserverEvent const

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ yarn add @untemps/dom-observer
 Import `DOMObserver`:
 
 ```javascript
-import { DOMObserver } from '@untemps/dom-observer'
+import { DOMObserver, DOMObserverEvent } from '@untemps/dom-observer'
 ```
 
 Create an instance of `DOMObserver`:
@@ -34,20 +34,20 @@ const observer = new DOMObserver()
 Use the `watch` method when you want to be notified **every time** a mutation occurs — for instance, tracking all successive attribute changes on an element or reacting to every matching node added to the DOM.
 
 ```javascript
-import { DOMObserver } from '@untemps/dom-observer'
+import { DOMObserver, DOMObserverEvent } from '@untemps/dom-observer'
 
 // Track every attribute change on an element
 const observer = new DOMObserver()
 observer.watch('#foo', ({ node, options }) => {
 	console.log(`${options?.attributeName} changed from ${options?.oldValue} to ${node.getAttribute(options?.attributeName ?? '')}`)
-}, { events: [DOMObserver.CHANGE] })
+}, { events: [DOMObserverEvent.CHANGE] })
 
 // React to every matching node added or removed
 const listObserver = new DOMObserver()
 listObserver.watch('.list-item', ({ node, event }) => {
-	if (event === DOMObserver.ADD) console.log(`Item added: ${node.textContent}`)
-	if (event === DOMObserver.REMOVE) console.log(`Item removed: ${node.textContent}`)
-}, { events: [DOMObserver.ADD, DOMObserver.REMOVE] })
+	if (event === DOMObserverEvent.ADD) console.log(`Item added: ${node.textContent}`)
+	if (event === DOMObserverEvent.REMOVE) console.log(`Item removed: ${node.textContent}`)
+}, { events: [DOMObserverEvent.ADD, DOMObserverEvent.REMOVE] })
 ```
 
 Unlike `wait`, `watch` does not return a Promise. It returns `this`, allowing method chaining. Call `clear()` to stop the observation.
@@ -57,7 +57,7 @@ Pass `once: true` to stop the observation automatically after the first matching
 ```javascript
 observer.watch('#foo', ({ node }) => {
 	doSomething(node)  // called exactly once
-}, { events: [DOMObserver.ADD], once: true })
+}, { events: [DOMObserverEvent.ADD], once: true })
 ```
 
 Pass `debounce` to delay the callback until mutations have stopped for a given number of milliseconds — useful when you only care about the final state after a burst of rapid changes:
@@ -66,7 +66,7 @@ Pass `debounce` to delay the callback until mutations have stopped for a given n
 observer.watch('#progress', ({ node }) => {
 	console.log('final value:', node.getAttribute('data-value'))
 }, {
-	events: [DOMObserver.CHANGE],
+	events: [DOMObserverEvent.CHANGE],
 	attributeFilter: ['data-value'],
 	debounce: 100,
 })
@@ -79,7 +79,7 @@ const observer = new DOMObserver()
 observer.watch('#foo', ({ node, event }) => {
 	console.log(`Event: ${event}`)
 }, {
-	events: [DOMObserver.ADD],
+	events: [DOMObserverEvent.ADD],
 	timeout: 3000,
 	onError: (err) => console.error(err.message),
 })
@@ -93,7 +93,7 @@ observer.watch('#foo', ({ node, event }) => {
 | `onEvent`           | Function          | Callback triggered each time an event occurs on the observed element                                                                                    |
 | `options`           | Object            | Options object:                                                                                                                                          |
 | - `events`          | Array             | List of [events](#events) to observe (All events are observed by default)                                                                                |
-| - `attributeFilter` | Array             | List of attribute names to observe (DOMObserver.CHANGE event only)                                                                                       |
+| - `attributeFilter` | Array             | List of attribute names to observe (DOMObserverEvent.CHANGE event only)                                                                                       |
 | - `timeout`         | Number            | Duration (in ms) after which observation stops if no matching mutation occurred. Triggers `onError` with a `TimeoutError` when elapsed. Must be `0` or a positive finite number — throws `InvalidTimeoutError` otherwise. |
 | - `onError`         | Function          | Callback triggered when `timeout` elapses with no matching mutation                                                                                      |
 | - `signal`          | AbortSignal       | An `AbortSignal` to stop the observation. If already aborted, `watch()` returns immediately without observing.                                           |
@@ -108,7 +108,7 @@ The callback receives a single `EventPayload` object — a **discriminated union
 
 ```typescript
 observer.watch('#foo', ({ event, node, options }) => {
-	if (event === DOMObserver.CHANGE) {
+	if (event === DOMObserverEvent.CHANGE) {
 		console.log(options.attributeName) // ✅ ChangeOptions — never undefined here
 	}
 })
@@ -133,16 +133,16 @@ observer.watch('#foo', ({ event, node, options }) => {
 Use the `wait` method to get a Promise that resolves on the **first** matching mutation.
 
 ```javascript
-import { DOMObserver } from '@untemps/dom-observer'
+import { DOMObserver, DOMObserverEvent } from '@untemps/dom-observer'
 
 const observer = new DOMObserver()
-const result = await observer.wait('#foo', { events: [DOMObserver.REMOVE, DOMObserver.CHANGE] })
+const result = await observer.wait('#foo', { events: [DOMObserverEvent.REMOVE, DOMObserverEvent.CHANGE] })
 switch (result.event) {
-	case DOMObserver.REMOVE: {
+	case DOMObserverEvent.REMOVE: {
 		console.log('Element ' + result.node.id + ' has been removed')
 		break
 	}
-	case DOMObserver.CHANGE: {
+	case DOMObserverEvent.CHANGE: {
 		// options is ChangeOptions here — no fallback needed
 		console.log('Element ' + result.node.id + ' has been changed (' + result.options.attributeName + ')')
 		break
@@ -154,7 +154,7 @@ Pass an **array of targets** to resolve as soon as any one of them fires a match
 
 ```javascript
 const { node, target } = await observer.wait(['#success', '#error'], {
-	events: [DOMObserver.ADD],
+	events: [DOMObserverEvent.ADD],
 })
 console.log(`Matched: ${target}`)
 ```
@@ -177,7 +177,7 @@ Calling `clear()` after `wait()` resolves is safe and is a no-op. If a `timeout`
 | `options`           | Object            | Options object:                                                                                                                                          |
 | - `events`          | Array             | List of [events](#events) to observe (All events are observed by default)                                                                                |
 | - `timeout`         | Number            | Duration (in ms) before rejecting the Promise with a `TimeoutError`. `0` disables the timeout. Must be `0` or a positive finite number — rejects with `InvalidTimeoutError` otherwise. |
-| - `attributeFilter` | Array             | List of attribute names to observe (DOMObserver.CHANGE event only)                                                                                       |
+| - `attributeFilter` | Array             | List of attribute names to observe (DOMObserverEvent.CHANGE event only)                                                                                       |
 | - `signal`          | AbortSignal       | An `AbortSignal` to cancel the observation. If already aborted, the Promise rejects immediately with an `AbortError`.                                    |
 | - `root`            | Element or String | DOM element or CSS selector to use as the observation root. Only mutations within this subtree are observed. Defaults to `document.documentElement`.     |
 | - `filter`          | Function          | `(payload: EventPayload) => boolean`. Called before resolving the Promise. Return `false` to skip the event and keep waiting.                                 |
@@ -195,21 +195,21 @@ Calling `clear()` after `wait()` resolves is safe and is a no-op. If a `timeout`
 
 #### Events
 
-DOMObserver static properties list all observable events.
+All observable event constants are exported from the `DOMObserverEvent` object.
 
 | Props                | Description                                                                               |
 |----------------------|-------------------------------------------------------------------------------------------|
-| `DOMObserver.EXIST`  | Observe whether the element is already present in the DOM at observation start            |
-| `DOMObserver.ADD`    | Observe when the element is added to the DOM                                              |
-| `DOMObserver.REMOVE` | Observe when the element is removed from the DOM                                          |
-| `DOMObserver.CHANGE` | Observe when an attribute has changed on the element                                      |
-| `DOMObserver.EVENTS` | Array of all four events                                                                  |
+| `DOMObserverEvent.EXIST`  | Observe whether the element is already present in the DOM at observation start            |
+| `DOMObserverEvent.ADD`    | Observe when the element is added to the DOM                                              |
+| `DOMObserverEvent.REMOVE` | Observe when the element is removed from the DOM                                          |
+| `DOMObserverEvent.CHANGE` | Observe when an attribute has changed on the element                                      |
+| `DOMObserverEvents` | Array of all four events                                                                  |
 
 One or more events can be passed to the `events` option of `wait` or `watch`. By default, all events are observed.
 
 ```javascript
-{ events: [DOMObserver.ADD, DOMObserver.REMOVE] }
-{ events: DOMObserver.EVENTS }
+{ events: [DOMObserverEvent.ADD, DOMObserverEvent.REMOVE] }
+{ events: DOMObserverEvents }
 ```
 
 ### Check observation state
@@ -254,7 +254,7 @@ observer.clear().watch('#bar', onEvent)
 The library exports typed `Error` subclasses for reliable error handling with `instanceof` checks:
 
 ```typescript
-import { DOMObserver, TimeoutError, ObservationAbortedError } from '@untemps/dom-observer'
+import { DOMObserver, DOMObserverEvent, TimeoutError, ObservationAbortedError } from '@untemps/dom-observer'
 
 try {
     await observer.wait('#foo', { timeout: 500 })
@@ -279,7 +279,7 @@ try {
 ## Example
 
 ```javascript
-import { DOMObserver } from '@untemps/dom-observer'
+import { DOMObserver, DOMObserverEvent } from '@untemps/dom-observer'
 
 // Continuous observation with timeout
 const onError = (err) => console.error(err.message)
@@ -288,26 +288,26 @@ observer.watch(
     '.foo',
     ({ node, event, options }) => {
         switch (event) {
-            case DOMObserver.EXIST: {
+            case DOMObserverEvent.EXIST: {
                 console.log('Element ' + node.id + ' exists already')
                 break
             }
-            case DOMObserver.ADD: {
+            case DOMObserverEvent.ADD: {
                 console.log('Element ' + node.id + ' has been added')
                 break
             }
-            case DOMObserver.REMOVE: {
+            case DOMObserverEvent.REMOVE: {
                 console.log('Element ' + node.id + ' has been removed')
                 break
             }
-            case DOMObserver.CHANGE: {
+            case DOMObserverEvent.CHANGE: {
                 console.log('Element ' + node.id + ' has been changed (' + options?.attributeName + ')')
                 break
             }
         }
     },
     {
-        events: [DOMObserver.EXIST, DOMObserver.ADD, DOMObserver.REMOVE, DOMObserver.CHANGE],
+        events: [DOMObserverEvent.EXIST, DOMObserverEvent.ADD, DOMObserverEvent.REMOVE, DOMObserverEvent.CHANGE],
         timeout: 2000,
         onError,
         attributeFilter: ['class'],

--- a/dev/src/index.js
+++ b/dev/src/index.js
@@ -1,4 +1,4 @@
-import { DOMObserver } from '../../src'
+import { DOMObserver, DOMObserverEvent } from '../../src'
 
 import { createCard, createTooltip } from './elements'
 import { log } from './log'
@@ -27,27 +27,27 @@ addButton.addEventListener('click', () => {
 	}
 })
 
-const onEvent = ({ node, event, options: { attributeName } = {} }) => {
+const onEvent = ({ node, event, options }) => {
 	switch (event) {
-		case DOMObserver.ADD: {
+		case DOMObserverEvent.ADD: {
 			log(`[ADD]\t\tElement id: ${node.id}`)
 			break
 		}
-		case DOMObserver.REMOVE: {
+		case DOMObserverEvent.REMOVE: {
 			log(`[REMOVE]\tElement id: ${node.id}`)
 			break
 		}
 		default: {
-			log(`[CHANGE]\tElement id: ${node.id} - Attribute: ${attributeName}`)
+			log(`[CHANGE]\tElement id: ${node.id} - Attribute: ${options?.attributeName}`)
 		}
 	}
 }
 
 const tooltipObserver = new DOMObserver()
-tooltipObserver.watch(tooltip, onEvent, { events: [DOMObserver.ADD, DOMObserver.REMOVE] })
+tooltipObserver.watch(tooltip, onEvent, { events: [DOMObserverEvent.ADD, DOMObserverEvent.REMOVE] })
 
 const cardObserver = new DOMObserver()
 cardObserver.wait(`#card`).then(({ node }) => {
 	log(`[ADD]\t\tElement id: ${node.id}`)
-	new DOMObserver().watch(`#card`, onEvent, { events: [DOMObserver.REMOVE, DOMObserver.CHANGE] })
+	new DOMObserver().watch(`#card`, onEvent, { events: [DOMObserverEvent.REMOVE, DOMObserverEvent.CHANGE] })
 })

--- a/src/DOMObserver.ts
+++ b/src/DOMObserver.ts
@@ -5,13 +5,28 @@ import resolveDOMTarget from './utils/resolveDOMTarget'
 
 export type { DOMTarget }
 
-type ExistEvent = 'DOMObserver_exist'
-type AddEvent = 'DOMObserver_add'
-type RemoveEvent = 'DOMObserver_remove'
-type ChangeEvent = 'DOMObserver_change'
+/** Enumeration of all event types emitted by DOMObserver. */
+export const DOMObserverEvent = {
+	/** Fired synchronously when the target element is already present in the DOM at observation time. */
+	EXIST: 'DOMObserver_exist',
+	/** Fired when the target element is added to the DOM. */
+	ADD: 'DOMObserver_add',
+	/** Fired when the target element is removed from the DOM. */
+	REMOVE: 'DOMObserver_remove',
+	/** Fired when an attribute of the target element changes. */
+	CHANGE: 'DOMObserver_change',
+} as const
 
-/** Union of all event types emitted by DOMObserver. */
-export type DOMObserverEvent = ExistEvent | AddEvent | RemoveEvent | ChangeEvent
+/** Union of all event type values emitted by DOMObserver. */
+export type DOMObserverEventValue = (typeof DOMObserverEvent)[keyof typeof DOMObserverEvent]
+
+/** Convenience array of all event types, used as the default value for the `events` option. */
+export const DOMObserverEvents: DOMObserverEventValue[] = Object.values(DOMObserverEvent)
+
+type ExistEvent = typeof DOMObserverEvent.EXIST
+type AddEvent = typeof DOMObserverEvent.ADD
+type RemoveEvent = typeof DOMObserverEvent.REMOVE
+type ChangeEvent = typeof DOMObserverEvent.CHANGE
 
 /** Metadata attached to a `CHANGE` event, mirroring the relevant fields of `MutationRecord`. */
 export interface ChangeOptions {
@@ -65,7 +80,7 @@ export interface ChangePayload {
  * @example
  * ```typescript
  * obs.watch('#foo', ({ event, node, options }) => {
- *   if (event === DOMObserver.CHANGE) {
+ *   if (event === DOMObserverEvent.CHANGE) {
  *     console.log(options.attributeName) // ✅ ChangeOptions — not undefined
  *   }
  * })
@@ -95,7 +110,7 @@ export type WaitResult = EventPayload & {
 /** Options accepted by `wait()`. */
 export interface WaitOptions {
 	/** Event types to listen for. Defaults to all four event types. */
-	events?: DOMObserverEvent[]
+	events?: DOMObserverEventValue[]
 	/** Maximum time in milliseconds to wait before rejecting with a `TimeoutError`. `0` disables the timeout. Must be `0` or a positive finite number — rejects with `InvalidTimeoutError` otherwise. */
 	timeout?: number
 	/** Restrict attribute observation to these attribute names. Passed directly to `MutationObserver.observe()`. */
@@ -111,7 +126,7 @@ export interface WaitOptions {
 /** Options accepted by `watch()`. */
 export interface WatchOptions {
 	/** Event types to listen for. Defaults to all four event types. */
-	events?: DOMObserverEvent[]
+	events?: DOMObserverEventValue[]
 	/** Restrict attribute observation to these attribute names. Passed directly to `MutationObserver.observe()`. */
 	attributeFilter?: string[]
 	/**
@@ -138,17 +153,6 @@ export interface WatchOptions {
 }
 
 class DOMObserver {
-	/** Fired synchronously when the target element is already present in the DOM at observation time. */
-	static EXIST = 'DOMObserver_exist' as const satisfies DOMObserverEvent
-	/** Fired when the target element is added to the DOM. */
-	static ADD = 'DOMObserver_add' as const satisfies DOMObserverEvent
-	/** Fired when the target element is removed from the DOM. */
-	static REMOVE = 'DOMObserver_remove' as const satisfies DOMObserverEvent
-	/** Fired when an attribute of the target element changes. */
-	static CHANGE = 'DOMObserver_change' as const satisfies DOMObserverEvent
-	/** Convenience array containing all four event types, used as the default value for the `events` option. */
-	static EVENTS: DOMObserverEvent[] = [DOMObserver.EXIST, DOMObserver.ADD, DOMObserver.REMOVE, DOMObserver.CHANGE]
-
 	private _observer: MutationObserver | null = null
 	private _pendingReject: ((error: Error | DOMException) => void) | null = null
 	private _signal: AbortSignal | null = null
@@ -187,7 +191,7 @@ class DOMObserver {
 	wait(
 		target: DOMTarget | DOMTarget[],
 		{
-			events = DOMObserver.EVENTS,
+			events = DOMObserverEvents,
 			timeout = 0,
 			attributeFilter = undefined,
 			signal = undefined,
@@ -286,7 +290,7 @@ class DOMObserver {
 		target: DOMTarget,
 		onEvent: OnEventCallback,
 		{
-			events = DOMObserver.EVENTS,
+			events = DOMObserverEvents,
 			attributeFilter = undefined,
 			timeout = 0,
 			onError = undefined,
@@ -359,19 +363,19 @@ class DOMObserver {
 			attributeFilter,
 			root,
 			filter,
-		}: { events: DOMObserverEvent[]; attributeFilter?: string[]; root?: DOMTarget; filter?: FilterCallback },
+		}: { events: DOMObserverEventValue[]; attributeFilter?: string[]; root?: DOMTarget; filter?: FilterCallback },
 		onMatch?: (matchedTarget: DOMTarget) => void
 	): void {
-		const hasExist = events.includes(DOMObserver.EXIST)
-		const hasAdd = events.includes(DOMObserver.ADD)
-		const hasRemove = events.includes(DOMObserver.REMOVE)
-		const hasChange = events.includes(DOMObserver.CHANGE)
+		const hasExist = events.includes(DOMObserverEvent.EXIST)
+		const hasAdd = events.includes(DOMObserverEvent.ADD)
+		const hasRemove = events.includes(DOMObserverEvent.REMOVE)
+		const hasChange = events.includes(DOMObserverEvent.CHANGE)
 
 		const targets = Array.isArray(target) ? target : [target]
 		const resolvedTargets = targets.map((t) => ({ target: t, el: resolveDOMTarget(t) }))
 		const defaultRoot = resolveDOMTarget(root) ?? document.documentElement
 
-		const fireCallback = (node: Element, event: DOMObserverEvent, opts?: ChangeOptions) => {
+		const fireCallback = (node: Element, event: DOMObserverEventValue, opts?: ChangeOptions) => {
 			const payload = (opts !== undefined ? { node, event, options: opts } : { node, event }) as EventPayload
 			if (filter && !filter(payload)) return
 			callback(payload)
@@ -380,7 +384,7 @@ class DOMObserver {
 		const nodeMatchesTarget = (node: Node, t: DOMTarget): boolean =>
 			node === t || (!isElement(t) && (node as Element).matches?.(t as string))
 
-		const notify = (node: Node, event: DOMObserverEvent) => {
+		const notify = (node: Node, event: DOMObserverEventValue) => {
 			for (const { target: t } of resolvedTargets) {
 				if (nodeMatchesTarget(node, t)) {
 					onMatch?.(t)
@@ -394,7 +398,7 @@ class DOMObserver {
 			for (const { target: t, el } of resolvedTargets) {
 				if (el) {
 					onMatch?.(t)
-					fireCallback(el, DOMObserver.EXIST)
+					fireCallback(el, DOMObserverEvent.EXIST)
 					break
 				}
 			}
@@ -403,14 +407,14 @@ class DOMObserver {
 		this._observer = new MutationObserver((mutations) => {
 			mutations.forEach(({ type, target: targetNode, addedNodes, removedNodes, attributeName, oldValue }) => {
 				if (type === 'childList' && (hasAdd || hasRemove)) {
-					if (hasAdd) for (const node of addedNodes) notify(node, DOMObserver.ADD)
-					if (hasRemove) for (const node of removedNodes) notify(node, DOMObserver.REMOVE)
+					if (hasAdd) for (const node of addedNodes) notify(node, DOMObserverEvent.ADD)
+					if (hasRemove) for (const node of removedNodes) notify(node, DOMObserverEvent.REMOVE)
 				}
 				if (type === 'attributes' && hasChange) {
 					for (const { target: t } of resolvedTargets) {
 						if (nodeMatchesTarget(targetNode, t)) {
 							onMatch?.(t)
-							fireCallback(targetNode as Element, DOMObserver.CHANGE, { attributeName, oldValue })
+							fireCallback(targetNode as Element, DOMObserverEvent.CHANGE, { attributeName, oldValue })
 							break
 						}
 					}

--- a/src/DOMObserver.ts
+++ b/src/DOMObserver.ts
@@ -21,7 +21,7 @@ export const DOMObserverEvent = {
 export type DOMObserverEventValue = (typeof DOMObserverEvent)[keyof typeof DOMObserverEvent]
 
 /** Convenience array of all event types, used as the default value for the `events` option. */
-export const DOMObserverEvents: DOMObserverEventValue[] = Object.values(DOMObserverEvent)
+export const DOMObserverEvents: readonly DOMObserverEventValue[] = Object.values(DOMObserverEvent)
 
 type ExistEvent = typeof DOMObserverEvent.EXIST
 type AddEvent = typeof DOMObserverEvent.ADD
@@ -110,7 +110,7 @@ export type WaitResult = EventPayload & {
 /** Options accepted by `wait()`. */
 export interface WaitOptions {
 	/** Event types to listen for. Defaults to all four event types. */
-	events?: DOMObserverEventValue[]
+	events?: readonly DOMObserverEventValue[]
 	/** Maximum time in milliseconds to wait before rejecting with a `TimeoutError`. `0` disables the timeout. Must be `0` or a positive finite number — rejects with `InvalidTimeoutError` otherwise. */
 	timeout?: number
 	/** Restrict attribute observation to these attribute names. Passed directly to `MutationObserver.observe()`. */
@@ -126,7 +126,7 @@ export interface WaitOptions {
 /** Options accepted by `watch()`. */
 export interface WatchOptions {
 	/** Event types to listen for. Defaults to all four event types. */
-	events?: DOMObserverEventValue[]
+	events?: readonly DOMObserverEventValue[]
 	/** Restrict attribute observation to these attribute names. Passed directly to `MutationObserver.observe()`. */
 	attributeFilter?: string[]
 	/**
@@ -363,7 +363,7 @@ class DOMObserver {
 			attributeFilter,
 			root,
 			filter,
-		}: { events: DOMObserverEventValue[]; attributeFilter?: string[]; root?: DOMTarget; filter?: FilterCallback },
+		}: { events: readonly DOMObserverEventValue[]; attributeFilter?: string[]; root?: DOMTarget; filter?: FilterCallback },
 		onMatch?: (matchedTarget: DOMTarget) => void
 	): void {
 		const hasExist = events.includes(DOMObserverEvent.EXIST)

--- a/src/__tests__/DOMObserver.test.ts
+++ b/src/__tests__/DOMObserver.test.ts
@@ -2,6 +2,7 @@ import {
 	type ChangeOptions,
 	type ChangePayload,
 	DOMObserver,
+	DOMObserverEvent,
 	type DOMTarget,
 	type EventPayload,
 	InvalidEventsError,
@@ -42,16 +43,16 @@ describe('DOMObserver', () => {
 				it('Observes an element to be added', async () => {
 					const { node: foundNode, event } = await instance.wait('#foo')
 					expect(foundNode).toEqual(node)
-					expect(event).toBe(DOMObserver.EXIST)
+					expect(event).toBe(DOMObserverEvent.EXIST)
 				})
 
 				it('Observes an element to be removed', async () => {
 					setTimeout(() => {
 						_removeElement('#foo')
 					}, 100)
-					const { node: foundNode, event } = await instance.wait('#foo', { events: [DOMObserver.REMOVE] })
+					const { node: foundNode, event } = await instance.wait('#foo', { events: [DOMObserverEvent.REMOVE] })
 					expect(foundNode).toEqual(node)
-					expect(event).toBe(DOMObserver.REMOVE)
+					expect(event).toBe(DOMObserverEvent.REMOVE)
 				})
 
 				it('Observes an element to be modified', async () => {
@@ -63,10 +64,10 @@ describe('DOMObserver', () => {
 						event,
 						options: { attributeName, oldValue } = {},
 					} = await instance.wait('#foo', {
-						events: [DOMObserver.CHANGE],
+						events: [DOMObserverEvent.CHANGE],
 					})
 					expect(foundNode).toEqual(node)
-					expect(event).toBe(DOMObserver.CHANGE)
+					expect(event).toBe(DOMObserverEvent.CHANGE)
 					expect(attributeName).toBe('class')
 					expect(oldValue).toBe('bar')
 				})
@@ -77,21 +78,21 @@ describe('DOMObserver', () => {
 						_modifyElement('#foo', 'data-watched', 'y')
 					}, 50)
 					const { options } = await instance.wait('#foo', {
-						events: [DOMObserver.CHANGE],
+						events: [DOMObserverEvent.CHANGE],
 						attributeFilter: ['data-watched'],
 					})
 					expect(options?.attributeName).toBe('data-watched')
 				})
 
 				it('Rejects promise when an element is not found after timeout is elapsed', async () => {
-					await expect(instance.wait('#bar', { events: [DOMObserver.ADD], timeout: 50 })).rejects.toThrow(
+					await expect(instance.wait('#bar', { events: [DOMObserverEvent.ADD], timeout: 50 })).rejects.toThrow(
 						TimeoutError
 					)
 				})
 
 				it('Rejects the pending promise when wait() is called again', async () => {
-					const first = instance.wait('#bar', { events: [DOMObserver.ADD] })
-					instance.wait('#baz', { events: [DOMObserver.ADD] })
+					const first = instance.wait('#bar', { events: [DOMObserverEvent.ADD] })
+					instance.wait('#baz', { events: [DOMObserverEvent.ADD] })
 					await expect(first).rejects.toThrow(ObservationAbortedError)
 				})
 
@@ -127,7 +128,7 @@ describe('DOMObserver', () => {
 				it('Rejects and disconnects when signal is aborted during observation', async () => {
 					const controller = new AbortController()
 					const promise = instance.wait('#bar', {
-						events: [DOMObserver.ADD],
+						events: [DOMObserverEvent.ADD],
 						signal: controller.signal,
 					})
 					setTimeout(() => controller.abort(), 50)
@@ -155,7 +156,7 @@ describe('DOMObserver', () => {
 
 				it('Does not clear a subsequent watch() when timeout was set', async () => {
 					await instance.wait('#foo', { timeout: 100 })
-					instance.watch('#foo', vi.fn<OnEventCallback>(), { events: [DOMObserver.CHANGE] })
+					instance.watch('#foo', vi.fn<OnEventCallback>(), { events: [DOMObserverEvent.CHANGE] })
 					await _sleep(150)
 					expect(instance.isObserving).toBe(true)
 				})
@@ -168,7 +169,7 @@ describe('DOMObserver', () => {
 						child.id = 'scoped'
 						root.appendChild(child)
 					}, 50)
-					const { node } = await instance.wait('#scoped', { events: [DOMObserver.ADD], root })
+					const { node } = await instance.wait('#scoped', { events: [DOMObserverEvent.ADD], root })
 					expect(node.id).toBe('scoped')
 					root.remove()
 				})
@@ -182,7 +183,7 @@ describe('DOMObserver', () => {
 						child.id = 'scoped2'
 						root.appendChild(child)
 					}, 50)
-					const { node } = await instance.wait('#scoped2', { events: [DOMObserver.ADD], root: '#root-scope' })
+					const { node } = await instance.wait('#scoped2', { events: [DOMObserverEvent.ADD], root: '#root-scope' })
 					expect(node.id).toBe('scoped2')
 					root.remove()
 				})
@@ -190,7 +191,7 @@ describe('DOMObserver', () => {
 				it('Resolves immediately when filter passes for an existing element', async () => {
 					const { node: foundNode, event } = await instance.wait('#foo', { filter: () => true })
 					expect(foundNode).toEqual(node)
-					expect(event).toBe(DOMObserver.EXIST)
+					expect(event).toBe(DOMObserverEvent.EXIST)
 				})
 
 				it('Skips nodes rejected by filter and resolves on the first passing one', async () => {
@@ -203,7 +204,7 @@ describe('DOMObserver', () => {
 						document.body.appendChild(btn)
 					}, 100)
 					const { node } = await instance.wait('button', {
-						events: [DOMObserver.ADD],
+						events: [DOMObserverEvent.ADD],
 						filter: ({ node }) => node.classList.contains('primary'),
 					})
 					expect(node.classList.contains('primary')).toBe(true)
@@ -214,7 +215,7 @@ describe('DOMObserver', () => {
 						document.body.appendChild(document.createElement('button'))
 					}, 30)
 					await expect(
-						instance.wait('button', { events: [DOMObserver.ADD], filter: () => false, timeout: 80 })
+						instance.wait('button', { events: [DOMObserverEvent.ADD], filter: () => false, timeout: 80 })
 					).rejects.toThrow(TimeoutError)
 				})
 
@@ -223,7 +224,7 @@ describe('DOMObserver', () => {
 					document.body.appendChild(btn)
 					setTimeout(() => btn.setAttribute('data-ready', 'true'), 50)
 					const { node } = await instance.wait('button', {
-						events: [DOMObserver.EXIST, DOMObserver.CHANGE],
+						events: [DOMObserverEvent.EXIST, DOMObserverEvent.CHANGE],
 						filter: ({ node }) => node.hasAttribute('data-ready'),
 					})
 					expect(node.getAttribute('data-ready')).toBe('true')
@@ -233,10 +234,10 @@ describe('DOMObserver', () => {
 				it('Passes ChangeOptions to filter for CHANGE events', async () => {
 					const filter = vi.fn(() => true)
 					setTimeout(() => _modifyElement('#foo', 'class', 'updated'), 50)
-					await instance.wait('#foo', { events: [DOMObserver.CHANGE], filter })
+					await instance.wait('#foo', { events: [DOMObserverEvent.CHANGE], filter })
 					expect(filter).toHaveBeenCalledWith({
 						node,
-						event: DOMObserver.CHANGE,
+						event: DOMObserverEvent.CHANGE,
 						options: {
 							attributeName: 'class',
 							oldValue: 'bar',
@@ -257,7 +258,7 @@ describe('DOMObserver', () => {
 					}, 100)
 					const { node: foundNode, event } = await instance.wait('#foo')
 					expect(foundNode).toEqual(node)
-					expect(event).toBe(DOMObserver.ADD)
+					expect(event).toBe(DOMObserverEvent.ADD)
 				})
 			})
 		})
@@ -270,7 +271,7 @@ describe('DOMObserver', () => {
 			it('Resolves on EXIST for the first target found in the DOM', async () => {
 				const { node: foundNode, event, target } = await instance.wait(['#foo', '#bar'])
 				expect(foundNode).toEqual(node)
-				expect(event).toBe(DOMObserver.EXIST)
+				expect(event).toBe(DOMObserverEvent.EXIST)
 				expect(target).toBe('#foo')
 			})
 
@@ -290,7 +291,7 @@ describe('DOMObserver', () => {
 					div.id = 'winner'
 					document.body.appendChild(div)
 				}, 50)
-				const { node, target } = await instance.wait(['#winner', '#loser'], { events: [DOMObserver.ADD] })
+				const { node, target } = await instance.wait(['#winner', '#loser'], { events: [DOMObserverEvent.ADD] })
 				expect(node.id).toBe('winner')
 				expect(target).toBe('#winner')
 			})
@@ -302,7 +303,7 @@ describe('DOMObserver', () => {
 					document.body.appendChild(div)
 				}, 50)
 				const { node, target } = await instance.wait(['#first-never', '#second-wins'], {
-					events: [DOMObserver.ADD],
+					events: [DOMObserverEvent.ADD],
 				})
 				expect(node.id).toBe('second-wins')
 				expect(target).toBe('#second-wins')
@@ -314,14 +315,14 @@ describe('DOMObserver', () => {
 
 			it('Rejects with TimeoutError when no target matches within the time limit', async () => {
 				await expect(
-					instance.wait(['#missing1', '#missing2'], { events: [DOMObserver.ADD], timeout: 50 })
+					instance.wait(['#missing1', '#missing2'], { events: [DOMObserverEvent.ADD], timeout: 50 })
 				).rejects.toThrow(TimeoutError)
 			})
 
 			it('Rejects with AbortError when signal is aborted during multi-target observation', async () => {
 				const controller = new AbortController()
 				const promise = instance.wait(['#missing1', '#missing2'], {
-					events: [DOMObserver.ADD],
+					events: [DOMObserverEvent.ADD],
 					signal: controller.signal,
 				})
 				setTimeout(() => controller.abort(), 50)
@@ -333,7 +334,7 @@ describe('DOMObserver', () => {
 				second.id = 'removable'
 				document.body.appendChild(second)
 				setTimeout(() => second.remove(), 50)
-				const { node, target } = await instance.wait(['#foo', '#removable'], { events: [DOMObserver.REMOVE] })
+				const { node, target } = await instance.wait(['#foo', '#removable'], { events: [DOMObserverEvent.REMOVE] })
 				expect(node.id).toBe('removable')
 				expect(target).toBe('#removable')
 			})
@@ -343,7 +344,7 @@ describe('DOMObserver', () => {
 				second.id = 'changeable'
 				document.body.appendChild(second)
 				setTimeout(() => second.setAttribute('data-x', '1'), 50)
-				const { node, target } = await instance.wait(['#foo', '#changeable'], { events: [DOMObserver.CHANGE] })
+				const { node, target } = await instance.wait(['#foo', '#changeable'], { events: [DOMObserverEvent.CHANGE] })
 				expect(node.id).toBe('changeable')
 				expect(target).toBe('#changeable')
 				second.remove()
@@ -362,7 +363,7 @@ describe('DOMObserver', () => {
 					document.body.appendChild(div)
 				}, 50)
 				const { node, target } = await instance.wait(['#filtered-a', '#filtered-b'], {
-					events: [DOMObserver.ADD],
+					events: [DOMObserverEvent.ADD],
 					filter: ({ node }) => {
 						callCount++
 						return node.id === 'filtered-b'
@@ -387,16 +388,16 @@ describe('DOMObserver', () => {
 
 			it('Triggers onEvent immediately with EXIST when element is present', () => {
 				instance.watch('#foo', onEvent)
-				expect(onEvent).toHaveBeenCalledWith({ node, event: DOMObserver.EXIST })
+				expect(onEvent).toHaveBeenCalledWith({ node, event: DOMObserverEvent.EXIST })
 			})
 
 			it('Accepts an Element reference as target', () => {
 				instance.watch(node, onEvent)
-				expect(onEvent).toHaveBeenCalledWith({ node, event: DOMObserver.EXIST })
+				expect(onEvent).toHaveBeenCalledWith({ node, event: DOMObserverEvent.EXIST })
 			})
 
 			it('Triggers onEvent on every successive attribute change', async () => {
-				instance.watch('#foo', onEvent, { events: [DOMObserver.CHANGE] })
+				instance.watch('#foo', onEvent, { events: [DOMObserverEvent.CHANGE] })
 				_modifyElement('#foo', 'class', 'change1')
 				await _sleep()
 				_modifyElement('#foo', 'class', 'change2')
@@ -404,7 +405,7 @@ describe('DOMObserver', () => {
 				expect(onEvent).toHaveBeenCalledTimes(2)
 				expect(onEvent).toHaveBeenNthCalledWith(1, {
 					node,
-					event: DOMObserver.CHANGE,
+					event: DOMObserverEvent.CHANGE,
 					options: {
 						attributeName: 'class',
 						oldValue: 'bar',
@@ -412,7 +413,7 @@ describe('DOMObserver', () => {
 				})
 				expect(onEvent).toHaveBeenNthCalledWith(2, {
 					node,
-					event: DOMObserver.CHANGE,
+					event: DOMObserverEvent.CHANGE,
 					options: {
 						attributeName: 'class',
 						oldValue: 'change1',
@@ -421,23 +422,23 @@ describe('DOMObserver', () => {
 			})
 
 			it('Triggers onEvent for each matching added and removed node', async () => {
-				instance.watch('.item', onEvent, { events: [DOMObserver.ADD, DOMObserver.REMOVE] })
+				instance.watch('.item', onEvent, { events: [DOMObserverEvent.ADD, DOMObserverEvent.REMOVE] })
 				const nodeA = _createElementWithClass('item')
 				const nodeB = _createElementWithClass('item')
 				await _sleep()
 				expect(onEvent).toHaveBeenCalledTimes(2)
-				expect(onEvent).toHaveBeenCalledWith({ node: nodeA, event: DOMObserver.ADD })
-				expect(onEvent).toHaveBeenCalledWith({ node: nodeB, event: DOMObserver.ADD })
+				expect(onEvent).toHaveBeenCalledWith({ node: nodeA, event: DOMObserverEvent.ADD })
+				expect(onEvent).toHaveBeenCalledWith({ node: nodeB, event: DOMObserverEvent.ADD })
 				document.body.removeChild(nodeA)
 				await _sleep()
-				expect(onEvent).toHaveBeenCalledWith({ node: nodeA, event: DOMObserver.REMOVE })
+				expect(onEvent).toHaveBeenCalledWith({ node: nodeA, event: DOMObserverEvent.REMOVE })
 				expect(onEvent).toHaveBeenCalledTimes(3)
 			})
 
 			it('Fires CHANGE for all elements matching a class selector, not just the first', async () => {
 				const nodeA = _createElementWithClass('item')
 				const nodeB = _createElementWithClass('item')
-				instance.watch('.item', onEvent, { events: [DOMObserver.CHANGE] })
+				instance.watch('.item', onEvent, { events: [DOMObserverEvent.CHANGE] })
 				nodeA.setAttribute('data-x', '1')
 				await _sleep()
 				nodeB.setAttribute('data-x', '2')
@@ -445,19 +446,19 @@ describe('DOMObserver', () => {
 				expect(onEvent).toHaveBeenCalledTimes(2)
 				expect(onEvent).toHaveBeenCalledWith({
 					node: nodeA,
-					event: DOMObserver.CHANGE,
+					event: DOMObserverEvent.CHANGE,
 					options: { attributeName: 'data-x', oldValue: null },
 				})
 				expect(onEvent).toHaveBeenCalledWith({
 					node: nodeB,
-					event: DOMObserver.CHANGE,
+					event: DOMObserverEvent.CHANGE,
 					options: { attributeName: 'data-x', oldValue: null },
 				})
 			})
 
 			it('Only fires for attributes in the filter list', async () => {
 				instance.watch('#foo', onEvent, {
-					events: [DOMObserver.CHANGE],
+					events: [DOMObserverEvent.CHANGE],
 					attributeFilter: ['data-watched'],
 				})
 				_modifyElement('#foo', 'data-ignored', 'x')
@@ -467,7 +468,7 @@ describe('DOMObserver', () => {
 				expect(onEvent).toHaveBeenCalledOnce()
 				expect(onEvent).toHaveBeenCalledWith({
 					node,
-					event: DOMObserver.CHANGE,
+					event: DOMObserverEvent.CHANGE,
 					options: {
 						attributeName: 'data-watched',
 						oldValue: null,
@@ -480,7 +481,7 @@ describe('DOMObserver', () => {
 				document.body.appendChild(root)
 				const inside = document.createElement('div')
 				inside.id = 'inside'
-				instance.watch('#inside', onEvent, { events: [DOMObserver.ADD], root })
+				instance.watch('#inside', onEvent, { events: [DOMObserverEvent.ADD], root })
 				root.appendChild(inside)
 				await _sleep()
 				expect(onEvent).toHaveBeenCalledOnce()
@@ -492,7 +493,7 @@ describe('DOMObserver', () => {
 				document.body.appendChild(root)
 				const outside = document.createElement('div')
 				outside.id = 'outside'
-				instance.watch('#outside', onEvent, { events: [DOMObserver.ADD], root })
+				instance.watch('#outside', onEvent, { events: [DOMObserverEvent.ADD], root })
 				document.body.appendChild(outside)
 				await _sleep()
 				expect(onEvent).not.toHaveBeenCalled()
@@ -506,7 +507,7 @@ describe('DOMObserver', () => {
 				document.body.appendChild(root)
 				const inside = document.createElement('div')
 				inside.id = 'inside2'
-				instance.watch('#inside2', onEvent, { events: [DOMObserver.ADD], root: '#watch-root' })
+				instance.watch('#inside2', onEvent, { events: [DOMObserverEvent.ADD], root: '#watch-root' })
 				root.appendChild(inside)
 				await _sleep()
 				expect(onEvent).toHaveBeenCalledOnce()
@@ -524,7 +525,7 @@ describe('DOMObserver', () => {
 				root.appendChild(watchedNode)
 				const outside = document.createElement('div')
 				document.body.appendChild(outside)
-				instance.watch(watchedNode, onEvent, { events: [DOMObserver.CHANGE], root })
+				instance.watch(watchedNode, onEvent, { events: [DOMObserverEvent.CHANGE], root })
 				outside.setAttribute('data-x', '1')
 				await _sleep()
 				expect(onEvent).not.toHaveBeenCalled()
@@ -536,14 +537,14 @@ describe('DOMObserver', () => {
 			})
 
 			it('Calls onEvent when filter passes', async () => {
-				instance.watch('#foo', onEvent, { events: [DOMObserver.CHANGE], filter: () => true })
+				instance.watch('#foo', onEvent, { events: [DOMObserverEvent.CHANGE], filter: () => true })
 				_modifyElement('#foo', 'class', 'change1')
 				await _sleep()
 				expect(onEvent).toHaveBeenCalledOnce()
 			})
 
 			it('Does not call onEvent when filter returns false', async () => {
-				instance.watch('#foo', onEvent, { events: [DOMObserver.CHANGE], filter: () => false })
+				instance.watch('#foo', onEvent, { events: [DOMObserverEvent.CHANGE], filter: () => false })
 				_modifyElement('#foo', 'class', 'change1')
 				await _sleep()
 				expect(onEvent).not.toHaveBeenCalled()
@@ -556,12 +557,12 @@ describe('DOMObserver', () => {
 
 			it('Passes ChangeOptions to filter for CHANGE events', async () => {
 				const filter = vi.fn(() => true)
-				instance.watch('#foo', onEvent, { events: [DOMObserver.CHANGE], filter })
+				instance.watch('#foo', onEvent, { events: [DOMObserverEvent.CHANGE], filter })
 				_modifyElement('#foo', 'class', 'updated')
 				await _sleep()
 				expect(filter).toHaveBeenCalledWith({
 					node,
-					event: DOMObserver.CHANGE,
+					event: DOMObserverEvent.CHANGE,
 					options: { attributeName: 'class', oldValue: 'bar' },
 				})
 			})
@@ -570,7 +571,7 @@ describe('DOMObserver', () => {
 				const inside = document.createElement('div')
 				inside.id = 'allowed'
 				instance.watch('div', onEvent, {
-					events: [DOMObserver.ADD],
+					events: [DOMObserverEvent.ADD],
 					filter: ({ node }) => node.id === 'allowed',
 				})
 				document.body.appendChild(document.createElement('div'))
@@ -583,7 +584,7 @@ describe('DOMObserver', () => {
 			})
 
 			it('Does not fire once when filter blocks all events', async () => {
-				instance.watch('#foo', onEvent, { events: [DOMObserver.CHANGE], once: true, filter: () => false })
+				instance.watch('#foo', onEvent, { events: [DOMObserverEvent.CHANGE], once: true, filter: () => false })
 				_modifyElement('#foo', 'class', 'change1')
 				await _sleep()
 				expect(onEvent).not.toHaveBeenCalled()
@@ -591,7 +592,7 @@ describe('DOMObserver', () => {
 			})
 
 			it('Fires once and stops when filter passes', async () => {
-				instance.watch('#foo', onEvent, { events: [DOMObserver.CHANGE], once: true, filter: () => true })
+				instance.watch('#foo', onEvent, { events: [DOMObserverEvent.CHANGE], once: true, filter: () => true })
 				_modifyElement('#foo', 'class', 'change1')
 				await _sleep()
 				expect(onEvent).toHaveBeenCalledOnce()
@@ -616,7 +617,7 @@ describe('DOMObserver', () => {
 			})
 
 			it('Rejects the pending wait() promise when watch() is called', async () => {
-				const pending = instance.wait('#bar', { events: [DOMObserver.ADD] })
+				const pending = instance.wait('#bar', { events: [DOMObserverEvent.ADD] })
 				instance.watch('#foo', onEvent)
 				await expect(pending).rejects.toThrow(ObservationAbortedError)
 			})
@@ -636,7 +637,7 @@ describe('DOMObserver', () => {
 
 			it('Stops observation when signal is aborted', async () => {
 				const controller = new AbortController()
-				instance.watch('#foo', onEvent, { events: [DOMObserver.CHANGE], signal: controller.signal })
+				instance.watch('#foo', onEvent, { events: [DOMObserverEvent.CHANGE], signal: controller.signal })
 				_modifyElement('#foo', 'class', 'change1')
 				await _sleep()
 				expect(onEvent).toHaveBeenCalledTimes(1)
@@ -648,7 +649,7 @@ describe('DOMObserver', () => {
 
 			it('Calls onError when timeout elapses with no matching mutation', async () => {
 				const onError = vi.fn()
-				instance.watch('#bar', onEvent, { events: [DOMObserver.ADD], timeout: 50, onError })
+				instance.watch('#bar', onEvent, { events: [DOMObserverEvent.ADD], timeout: 50, onError })
 				await _sleep(100)
 				expect(onEvent).not.toHaveBeenCalled()
 				expect(onError).toHaveBeenCalledOnce()
@@ -657,7 +658,7 @@ describe('DOMObserver', () => {
 
 			it('Does not call onError when a mutation occurs before timeout', async () => {
 				const onError = vi.fn()
-				instance.watch('#foo', onEvent, { events: [DOMObserver.CHANGE], timeout: 200, onError })
+				instance.watch('#foo', onEvent, { events: [DOMObserverEvent.CHANGE], timeout: 200, onError })
 				_modifyElement('#foo', 'class', 'change1')
 				await _sleep()
 				expect(onEvent).toHaveBeenCalledOnce()
@@ -667,13 +668,13 @@ describe('DOMObserver', () => {
 
 			it('Stops observation after timeout elapses', async () => {
 				const onError = vi.fn()
-				instance.watch('#foo', onEvent, { events: [DOMObserver.CHANGE], timeout: 50, onError })
+				instance.watch('#foo', onEvent, { events: [DOMObserverEvent.CHANGE], timeout: 50, onError })
 				await _sleep(100)
 				expect(instance.isObserving).toBe(false)
 			})
 
 			it('Fires onEvent only once when once is true', async () => {
-				instance.watch('#foo', onEvent, { events: [DOMObserver.CHANGE], once: true })
+				instance.watch('#foo', onEvent, { events: [DOMObserverEvent.CHANGE], once: true })
 				_modifyElement('#foo', 'class', 'change1')
 				await _sleep()
 				_modifyElement('#foo', 'class', 'change2')
@@ -682,7 +683,7 @@ describe('DOMObserver', () => {
 			})
 
 			it('Sets isObserving to false after the first event when once is true', async () => {
-				instance.watch('#foo', onEvent, { events: [DOMObserver.CHANGE], once: true })
+				instance.watch('#foo', onEvent, { events: [DOMObserverEvent.CHANGE], once: true })
 				_modifyElement('#foo', 'class', 'change1')
 				await _sleep()
 				expect(instance.isObserving).toBe(false)
@@ -690,7 +691,7 @@ describe('DOMObserver', () => {
 
 			it('Cancels timeout after the first event when once and timeout are both set', async () => {
 				const onError = vi.fn()
-				instance.watch('#foo', onEvent, { events: [DOMObserver.CHANGE], once: true, timeout: 200, onError })
+				instance.watch('#foo', onEvent, { events: [DOMObserverEvent.CHANGE], once: true, timeout: 200, onError })
 				_modifyElement('#foo', 'class', 'change1')
 				await _sleep()
 				expect(onEvent).toHaveBeenCalledOnce()
@@ -699,7 +700,7 @@ describe('DOMObserver', () => {
 			})
 
 			it('Fires onEvent once after a burst of mutations when debounce is set', async () => {
-				instance.watch('#foo', onEvent, { events: [DOMObserver.CHANGE], debounce: 50 })
+				instance.watch('#foo', onEvent, { events: [DOMObserverEvent.CHANGE], debounce: 50 })
 				_modifyElement('#foo', 'class', 'change1')
 				_modifyElement('#foo', 'class', 'change2')
 				_modifyElement('#foo', 'class', 'change3')
@@ -708,13 +709,13 @@ describe('DOMObserver', () => {
 			})
 
 			it('Forwards the last mutation arguments when debounce is set', async () => {
-				instance.watch('#foo', onEvent, { events: [DOMObserver.CHANGE], debounce: 50 })
+				instance.watch('#foo', onEvent, { events: [DOMObserverEvent.CHANGE], debounce: 50 })
 				_modifyElement('#foo', 'class', 'change1')
 				_modifyElement('#foo', 'class', 'change2')
 				await _sleep(150)
 				expect(onEvent).toHaveBeenCalledWith({
 					node,
-					event: DOMObserver.CHANGE,
+					event: DOMObserverEvent.CHANGE,
 					options: {
 						attributeName: 'class',
 						oldValue: 'change1',
@@ -723,7 +724,7 @@ describe('DOMObserver', () => {
 			})
 
 			it('Does not fire onEvent when clear() is called during the debounce period', async () => {
-				instance.watch('#foo', onEvent, { events: [DOMObserver.CHANGE], debounce: 100 })
+				instance.watch('#foo', onEvent, { events: [DOMObserverEvent.CHANGE], debounce: 100 })
 				_modifyElement('#foo', 'class', 'change1')
 				instance.clear()
 				await _sleep(200)
@@ -731,7 +732,7 @@ describe('DOMObserver', () => {
 			})
 
 			it('Fires onEvent once and stops when debounce and once are both set', async () => {
-				instance.watch('#foo', onEvent, { events: [DOMObserver.CHANGE], debounce: 50, once: true })
+				instance.watch('#foo', onEvent, { events: [DOMObserverEvent.CHANGE], debounce: 50, once: true })
 				_modifyElement('#foo', 'class', 'change1')
 				_modifyElement('#foo', 'class', 'change2')
 				await _sleep(150)
@@ -741,7 +742,7 @@ describe('DOMObserver', () => {
 
 			it('Fires onError on timeout when no mutation occurs even with debounce set', async () => {
 				const onError = vi.fn()
-				instance.watch('#bar', onEvent, { events: [DOMObserver.ADD], timeout: 50, debounce: 200, onError })
+				instance.watch('#bar', onEvent, { events: [DOMObserverEvent.ADD], timeout: 50, debounce: 200, onError })
 				await _sleep(100)
 				expect(onEvent).not.toHaveBeenCalled()
 				expect(onError).toHaveBeenCalledOnce()
@@ -753,7 +754,7 @@ describe('DOMObserver', () => {
 				instance.watch('#foo', onEvent)
 				node = _createElement('foo')
 				await _sleep()
-				expect(onEvent).toHaveBeenCalledWith({ node, event: DOMObserver.ADD })
+				expect(onEvent).toHaveBeenCalledWith({ node, event: DOMObserverEvent.ADD })
 			})
 		})
 	})
@@ -785,13 +786,13 @@ describe('EventPayload type narrowing', () => {
 			instance.watch(
 				'#foo',
 				({ event, options }) => {
-					if (event === DOMObserver.CHANGE) {
+					if (event === DOMObserverEvent.CHANGE) {
 						expectTypeOf(options).toEqualTypeOf<ChangeOptions>()
 						expect(options.attributeName).toBe('data-x')
 						resolve()
 					}
 				},
-				{ events: [DOMObserver.CHANGE] }
+				{ events: [DOMObserverEvent.CHANGE] }
 			)
 		})
 	})
@@ -799,13 +800,13 @@ describe('EventPayload type narrowing', () => {
 	it('options is absent for non-CHANGE events', async () => {
 		const captured: EventPayload[] = []
 
-		instance.watch('#foo', (payload) => captured.push(payload), { events: [DOMObserver.ADD] })
+		instance.watch('#foo', (payload) => captured.push(payload), { events: [DOMObserverEvent.ADD] })
 
 		_createElement('foo')
 		await _sleep()
 
 		expect(captured).toHaveLength(1)
-		expect(captured[0].event).toBe(DOMObserver.ADD)
+		expect(captured[0].event).toBe(DOMObserverEvent.ADD)
 		expect(captured[0].options).toBeUndefined()
 	})
 
@@ -813,10 +814,10 @@ describe('EventPayload type narrowing', () => {
 		_createElement('foo')
 		setTimeout(() => _modifyElement('#foo', 'class', 'updated'), 50)
 
-		const result = await instance.wait('#foo', { events: [DOMObserver.CHANGE] })
+		const result = await instance.wait('#foo', { events: [DOMObserverEvent.CHANGE] })
 
-		expect(result.event).toBe(DOMObserver.CHANGE)
-		if (result.event === DOMObserver.CHANGE) {
+		expect(result.event).toBe(DOMObserverEvent.CHANGE)
+		if (result.event === DOMObserverEvent.CHANGE) {
 			expectTypeOf(result).toEqualTypeOf<ChangePayload & { target?: DOMTarget }>()
 			expect(result.options.attributeName).toBe('class')
 		}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ export type {
 	AddPayload,
 	ChangeOptions,
 	ChangePayload,
-	DOMObserverEvent,
+	DOMObserverEventValue,
 	DOMTarget,
 	EventPayload,
 	ExistPayload,
@@ -13,7 +13,7 @@ export type {
 	WaitResult,
 	WatchOptions,
 } from './DOMObserver'
-export { default as DOMObserver } from './DOMObserver'
+export { default as DOMObserver, DOMObserverEvent, DOMObserverEvents } from './DOMObserver'
 export {
 	InvalidEventsError,
 	InvalidOptionsError,


### PR DESCRIPTION
## Summary

Replaces the five static class properties (`DOMObserver.EXIST`, `ADD`, `REMOVE`, `CHANGE`, `EVENTS`) with standalone exported constants. A new `DOMObserverEvent` as-const object holds all four event name constants. `DOMObserverEventValue` is the derived union type (replaces the old `DOMObserverEvent` type). `DOMObserverEvents` is a convenience array of all values (replaces `DOMObserver.EVENTS`). Internal per-event literal types now derive from `typeof DOMObserverEvent.X`, keeping a single source of truth per string value.

## Changes

- `src/DOMObserver.ts` — Add `export const DOMObserverEvent`, `export type DOMObserverEventValue`, `export const DOMObserverEvents`; remove five static class properties; update all internal references; rename `DOMObserverEvent` type to `DOMObserverEventValue`
- `src/index.ts` — Export `DOMObserverEvent` (value), `DOMObserverEvents` (value), `DOMObserverEventValue` (type)
- `src/__tests__/DOMObserver.test.ts` — Replace all `DOMObserver.X` constant references with `DOMObserverEvent.X`
- `README.md` — Update all examples and the Events reference table

## Test plan

- [ ] `npm run test:ci` passes (95 tests, 100% coverage)
- [ ] `DOMObserverEvent.CHANGE` etc. usable without importing the class
- [ ] `DOMObserverEventValue` is the correct union type for `events` option

## ⚠️ Breaking changes

| Before | After |
|---|---|
| `DOMObserver.ADD` | `DOMObserverEvent.ADD` |
| `DOMObserver.EXIST` | `DOMObserverEvent.EXIST` |
| `DOMObserver.REMOVE` | `DOMObserverEvent.REMOVE` |
| `DOMObserver.CHANGE` | `DOMObserverEvent.CHANGE` |
| `DOMObserver.EVENTS` | `DOMObserverEvents` |
| `type DOMObserverEvent` | `type DOMObserverEventValue` |

Migration: global find-and-replace covers most cases. The type rename only affects code that explicitly references `DOMObserverEvent` as a TypeScript type (not a value).

Closes #54