### PR TITLE
feat!: Expose createDOMObserver() factory and remove DOMObserver class export

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # @untemps/dom-observer
 
-Class to observe DOM mutations of a specific element in one-shot or continuous mode.
+Observe DOM mutations of a specific element in one-shot or continuous mode.
 
-The class is a wrapper around the MutationObserver API to target an element in particular.  
+A factory-based wrapper around the MutationObserver API targeting a specific element.  
 That means you can observe an element to be added to the DOM and access to its properties, an attribute from that element to be changed and get the old and the new values, the element to be removed from the DOM and destroy all its dependencies.
 
 ![npm](https://img.shields.io/npm/v/@untemps/dom-observer?style=for-the-badge)
@@ -17,16 +17,16 @@ yarn add @untemps/dom-observer
 
 ## Usage
 
-Import `DOMObserver`:
+Import `createDOMObserver`:
 
 ```javascript
-import { DOMObserver, DOMObserverEvent } from '@untemps/dom-observer'
+import { createDOMObserver, DOMObserverEvent } from '@untemps/dom-observer'
 ```
 
-Create an instance of `DOMObserver`:
+Create an observer instance:
 
 ```javascript
-const observer = new DOMObserver()
+const observer = createDOMObserver()
 ```
 
 ### Watch for recurring mutations
@@ -34,16 +34,16 @@ const observer = new DOMObserver()
 Use the `watch` method when you want to be notified **every time** a mutation occurs — for instance, tracking all successive attribute changes on an element or reacting to every matching node added to the DOM.
 
 ```javascript
-import { DOMObserver, DOMObserverEvent } from '@untemps/dom-observer'
+import { createDOMObserver, DOMObserverEvent } from '@untemps/dom-observer'
 
 // Track every attribute change on an element
-const observer = new DOMObserver()
+const observer = createDOMObserver()
 observer.watch('#foo', ({ node, options }) => {
 	console.log(`${options?.attributeName} changed from ${options?.oldValue} to ${node.getAttribute(options?.attributeName ?? '')}`)
 }, { events: [DOMObserverEvent.CHANGE] })
 
 // React to every matching node added or removed
-const listObserver = new DOMObserver()
+const listObserver = createDOMObserver()
 listObserver.watch('.list-item', ({ node, event }) => {
 	if (event === DOMObserverEvent.ADD) console.log(`Item added: ${node.textContent}`)
 	if (event === DOMObserverEvent.REMOVE) console.log(`Item removed: ${node.textContent}`)
@@ -75,7 +75,7 @@ observer.watch('#progress', ({ node }) => {
 Pass a `timeout` to automatically stop the observation if no matching mutation occurs within the allotted time:
 
 ```javascript
-const observer = new DOMObserver()
+const observer = createDOMObserver()
 observer.watch('#foo', ({ node, event }) => {
 	console.log(`Event: ${event}`)
 }, {
@@ -133,9 +133,9 @@ observer.watch('#foo', ({ event, node, options }) => {
 Use the `wait` method to get a Promise that resolves on the **first** matching mutation.
 
 ```javascript
-import { DOMObserver, DOMObserverEvent } from '@untemps/dom-observer'
+import { createDOMObserver, DOMObserverEvent } from '@untemps/dom-observer'
 
-const observer = new DOMObserver()
+const observer = createDOMObserver()
 const result = await observer.wait('#foo', { events: [DOMObserverEvent.REMOVE, DOMObserverEvent.CHANGE] })
 switch (result.event) {
 	case DOMObserverEvent.REMOVE: {
@@ -162,7 +162,7 @@ console.log(`Matched: ${target}`)
 Once the first matching mutation occurs, the Promise resolves and the observation stops automatically — the internal observer is disconnected and all state is reset before the Promise settles. `isObserving` is `false` immediately after `await`:
 
 ```javascript
-const observer = new DOMObserver()
+const observer = createDOMObserver()
 const { node } = await observer.wait('#foo')
 console.log(observer.isObserving) // false — auto-cleared on resolution
 ```
@@ -217,11 +217,26 @@ One or more events can be passed to the `events` option of `wait` or `watch`. By
 The `isObserving` getter returns `true` when an observation is currently active:
 
 ```javascript
-const observer = new DOMObserver()
+const observer = createDOMObserver()
 observer.watch('#foo', ({ node, event }) => { /* ... */ })
 console.log(observer.isObserving) // true
 observer.clear()
 console.log(observer.isObserving) // false
+```
+
+### TypeScript: typing observer instances
+
+Use the exported `DOMObserverInstance` type to annotate variables that hold an observer:
+
+```typescript
+import { createDOMObserver, type DOMObserverInstance } from '@untemps/dom-observer'
+
+let observer: DOMObserverInstance
+
+function setup() {
+    observer = createDOMObserver()
+    observer.watch('#foo', ({ node }) => doSomething(node))
+}
 ```
 
 ### Discard observation
@@ -238,9 +253,9 @@ observer.clear().watch('#bar', onEvent)
 > **Note:** Calling `wait()` or `watch()` on an instance that already has a pending `wait()` Promise will automatically reject that Promise with an `ObservationAbortedError` before starting the new observation. Handle this rejection if necessary:
 >
 > ```javascript
-> import { DOMObserver, ObservationAbortedError } from '@untemps/dom-observer'
+> import { createDOMObserver, ObservationAbortedError } from '@untemps/dom-observer'
 >
-> const observer = new DOMObserver()
+> const observer = createDOMObserver()
 > observer.wait('#foo').catch((err) => {
 >     if (err instanceof ObservationAbortedError) return // replaced by a new observation
 >     throw err
@@ -254,8 +269,9 @@ observer.clear().watch('#bar', onEvent)
 The library exports typed `Error` subclasses for reliable error handling with `instanceof` checks:
 
 ```typescript
-import { DOMObserver, DOMObserverEvent, TimeoutError, ObservationAbortedError } from '@untemps/dom-observer'
+import { createDOMObserver, DOMObserverEvent, TimeoutError, ObservationAbortedError } from '@untemps/dom-observer'
 
+const observer = createDOMObserver()
 try {
     await observer.wait('#foo', { timeout: 500 })
 } catch (e) {
@@ -279,11 +295,11 @@ try {
 ## Example
 
 ```javascript
-import { DOMObserver, DOMObserverEvent } from '@untemps/dom-observer'
+import { createDOMObserver, DOMObserverEvent } from '@untemps/dom-observer'
 
 // Continuous observation with timeout
 const onError = (err) => console.error(err.message)
-const observer = new DOMObserver()
+const observer = createDOMObserver()
 observer.watch(
     '.foo',
     ({ node, event, options }) => {

--- a/dev/src/index.js
+++ b/dev/src/index.js
@@ -46,16 +46,23 @@ const onEvent = ({ node, event, options }) => {
 const tooltipObserver = createDOMObserver()
 tooltipObserver.watch(tooltip, onEvent, { events: [DOMObserverEvent.ADD, DOMObserverEvent.REMOVE] })
 
-const cardObserver = createDOMObserver()
-cardObserver.wait(`#card`).then(({ node }) => {
-	log(`[ADD]\t\tElement id: ${node.id}`)
-	const cardWatcher = createDOMObserver()
-	cardWatcher.watch(
-		`#card`,
-		(payload) => {
-			onEvent(payload)
-			if (payload.event === DOMObserverEvent.REMOVE) cardWatcher.clear()
-		},
-		{ events: [DOMObserverEvent.REMOVE, DOMObserverEvent.CHANGE] }
-	)
-})
+const watchCard = () => {
+	createDOMObserver()
+		.wait(`#card`)
+		.then(({ node }) => {
+			log(`[ADD]\t\tElement id: ${node.id}`)
+			const cardWatcher = createDOMObserver()
+			cardWatcher.watch(
+				`#card`,
+				(payload) => {
+					onEvent(payload)
+					if (payload.event === DOMObserverEvent.REMOVE) {
+						cardWatcher.clear()
+						watchCard()
+					}
+				},
+				{ events: [DOMObserverEvent.REMOVE, DOMObserverEvent.CHANGE] }
+			)
+		})
+}
+watchCard()

--- a/dev/src/index.js
+++ b/dev/src/index.js
@@ -1,4 +1,4 @@
-import { DOMObserver, DOMObserverEvent } from '../../src'
+import { createDOMObserver, DOMObserverEvent } from '../../src'
 
 import { createCard, createTooltip } from './elements'
 import { log } from './log'
@@ -43,11 +43,11 @@ const onEvent = ({ node, event, options }) => {
 	}
 }
 
-const tooltipObserver = new DOMObserver()
+const tooltipObserver = createDOMObserver()
 tooltipObserver.watch(tooltip, onEvent, { events: [DOMObserverEvent.ADD, DOMObserverEvent.REMOVE] })
 
-const cardObserver = new DOMObserver()
+const cardObserver = createDOMObserver()
 cardObserver.wait(`#card`).then(({ node }) => {
 	log(`[ADD]\t\tElement id: ${node.id}`)
-	new DOMObserver().watch(`#card`, onEvent, { events: [DOMObserverEvent.REMOVE, DOMObserverEvent.CHANGE] })
+	createDOMObserver().watch(`#card`, onEvent, { events: [DOMObserverEvent.REMOVE, DOMObserverEvent.CHANGE] })
 })

--- a/dev/src/index.js
+++ b/dev/src/index.js
@@ -49,5 +49,13 @@ tooltipObserver.watch(tooltip, onEvent, { events: [DOMObserverEvent.ADD, DOMObse
 const cardObserver = createDOMObserver()
 cardObserver.wait(`#card`).then(({ node }) => {
 	log(`[ADD]\t\tElement id: ${node.id}`)
-	createDOMObserver().watch(`#card`, onEvent, { events: [DOMObserverEvent.REMOVE, DOMObserverEvent.CHANGE] })
+	const cardWatcher = createDOMObserver()
+	cardWatcher.watch(
+		`#card`,
+		(payload) => {
+			onEvent(payload)
+			if (payload.event === DOMObserverEvent.REMOVE) cardWatcher.clear()
+		},
+		{ events: [DOMObserverEvent.REMOVE, DOMObserverEvent.CHANGE] }
+	)
 })

--- a/src/DOMObserver.ts
+++ b/src/DOMObserver.ts
@@ -471,7 +471,6 @@ class DOMObserver implements DOMObserverInstance {
 	}
 }
 
-/** Creates and returns a new DOM observer instance. */
 export function createDOMObserver(): DOMObserverInstance {
 	return new DOMObserver()
 }

--- a/src/DOMObserver.ts
+++ b/src/DOMObserver.ts
@@ -152,7 +152,17 @@ export interface WatchOptions {
 	filter?: FilterCallback
 }
 
-class DOMObserver {
+/** Public interface of the observer instance returned by `createDOMObserver()`. */
+export interface DOMObserverInstance {
+	/** `true` while an observation is active, `false` after `clear()` is called or the observation settles. */
+	readonly isObserving: boolean
+	wait(target: DOMTarget, options?: WaitOptions): Promise<WaitResult>
+	wait(targets: DOMTarget[], options?: WaitOptions): Promise<WaitResult>
+	watch(target: DOMTarget, onEvent: OnEventCallback, options?: WatchOptions): this
+	clear(): this
+}
+
+class DOMObserver implements DOMObserverInstance {
 	private _observer: MutationObserver | null = null
 	private _pendingReject: ((error: Error | DOMException) => void) | null = null
 	private _signal: AbortSignal | null = null
@@ -363,7 +373,12 @@ class DOMObserver {
 			attributeFilter,
 			root,
 			filter,
-		}: { events: readonly DOMObserverEventValue[]; attributeFilter?: string[]; root?: DOMTarget; filter?: FilterCallback },
+		}: {
+			events: readonly DOMObserverEventValue[]
+			attributeFilter?: string[]
+			root?: DOMTarget
+			filter?: FilterCallback
+		},
 		onMatch?: (matchedTarget: DOMTarget) => void
 	): void {
 		const hasExist = events.includes(DOMObserverEvent.EXIST)
@@ -456,4 +471,7 @@ class DOMObserver {
 	}
 }
 
-export default DOMObserver
+/** Creates and returns a new DOM observer instance. */
+export function createDOMObserver(): DOMObserverInstance {
+	return new DOMObserver()
+}

--- a/src/__tests__/DOMObserver.test.ts
+++ b/src/__tests__/DOMObserver.test.ts
@@ -15,7 +15,7 @@ import {
 	TimeoutError,
 } from '../index'
 
-describe('DOMObserver', () => {
+describe('createDOMObserver', () => {
 	let instance: DOMObserverInstance
 	let node: HTMLElement
 	let onEvent: ReturnType<typeof vi.fn<OnEventCallback>>
@@ -32,6 +32,15 @@ describe('DOMObserver', () => {
 
 	it('Creates an instance with no error', () => {
 		expect(() => createDOMObserver()).not.toThrow()
+	})
+
+	it('Returns independent instances', () => {
+		const a = createDOMObserver()
+		const b = createDOMObserver()
+		a.watch('#foo', vi.fn())
+		expect(a.isObserving).toBe(true)
+		expect(b.isObserving).toBe(false)
+		a.clear()
 	})
 
 	describe('wait', () => {

--- a/src/__tests__/DOMObserver.test.ts
+++ b/src/__tests__/DOMObserver.test.ts
@@ -1,8 +1,9 @@
 import {
 	type ChangeOptions,
 	type ChangePayload,
-	DOMObserver,
+	createDOMObserver,
 	DOMObserverEvent,
+	type DOMObserverInstance,
 	type DOMTarget,
 	type EventPayload,
 	InvalidEventsError,
@@ -15,12 +16,12 @@ import {
 } from '../index'
 
 describe('DOMObserver', () => {
-	let instance: DOMObserver
+	let instance: DOMObserverInstance
 	let node: HTMLElement
 	let onEvent: ReturnType<typeof vi.fn<OnEventCallback>>
 
 	beforeEach(() => {
-		instance = new DOMObserver()
+		instance = createDOMObserver()
 	})
 
 	afterEach(() => {
@@ -29,8 +30,8 @@ describe('DOMObserver', () => {
 		document.body.innerHTML = ''
 	})
 
-	it('Instantiates the class with no error', () => {
-		expect(() => new DOMObserver()).not.toThrow()
+	it('Creates an instance with no error', () => {
+		expect(() => createDOMObserver()).not.toThrow()
 	})
 
 	describe('wait', () => {
@@ -50,7 +51,9 @@ describe('DOMObserver', () => {
 					setTimeout(() => {
 						_removeElement('#foo')
 					}, 100)
-					const { node: foundNode, event } = await instance.wait('#foo', { events: [DOMObserverEvent.REMOVE] })
+					const { node: foundNode, event } = await instance.wait('#foo', {
+						events: [DOMObserverEvent.REMOVE],
+					})
 					expect(foundNode).toEqual(node)
 					expect(event).toBe(DOMObserverEvent.REMOVE)
 				})
@@ -85,9 +88,9 @@ describe('DOMObserver', () => {
 				})
 
 				it('Rejects promise when an element is not found after timeout is elapsed', async () => {
-					await expect(instance.wait('#bar', { events: [DOMObserverEvent.ADD], timeout: 50 })).rejects.toThrow(
-						TimeoutError
-					)
+					await expect(
+						instance.wait('#bar', { events: [DOMObserverEvent.ADD], timeout: 50 })
+					).rejects.toThrow(TimeoutError)
 				})
 
 				it('Rejects the pending promise when wait() is called again', async () => {
@@ -183,7 +186,10 @@ describe('DOMObserver', () => {
 						child.id = 'scoped2'
 						root.appendChild(child)
 					}, 50)
-					const { node } = await instance.wait('#scoped2', { events: [DOMObserverEvent.ADD], root: '#root-scope' })
+					const { node } = await instance.wait('#scoped2', {
+						events: [DOMObserverEvent.ADD],
+						root: '#root-scope',
+					})
 					expect(node.id).toBe('scoped2')
 					root.remove()
 				})
@@ -334,7 +340,9 @@ describe('DOMObserver', () => {
 				second.id = 'removable'
 				document.body.appendChild(second)
 				setTimeout(() => second.remove(), 50)
-				const { node, target } = await instance.wait(['#foo', '#removable'], { events: [DOMObserverEvent.REMOVE] })
+				const { node, target } = await instance.wait(['#foo', '#removable'], {
+					events: [DOMObserverEvent.REMOVE],
+				})
 				expect(node.id).toBe('removable')
 				expect(target).toBe('#removable')
 			})
@@ -344,7 +352,9 @@ describe('DOMObserver', () => {
 				second.id = 'changeable'
 				document.body.appendChild(second)
 				setTimeout(() => second.setAttribute('data-x', '1'), 50)
-				const { node, target } = await instance.wait(['#foo', '#changeable'], { events: [DOMObserverEvent.CHANGE] })
+				const { node, target } = await instance.wait(['#foo', '#changeable'], {
+					events: [DOMObserverEvent.CHANGE],
+				})
 				expect(node.id).toBe('changeable')
 				expect(target).toBe('#changeable')
 				second.remove()
@@ -691,7 +701,12 @@ describe('DOMObserver', () => {
 
 			it('Cancels timeout after the first event when once and timeout are both set', async () => {
 				const onError = vi.fn()
-				instance.watch('#foo', onEvent, { events: [DOMObserverEvent.CHANGE], once: true, timeout: 200, onError })
+				instance.watch('#foo', onEvent, {
+					events: [DOMObserverEvent.CHANGE],
+					once: true,
+					timeout: 200,
+					onError,
+				})
 				_modifyElement('#foo', 'class', 'change1')
 				await _sleep()
 				expect(onEvent).toHaveBeenCalledOnce()
@@ -767,10 +782,10 @@ describe('DOMObserver', () => {
 })
 
 describe('EventPayload type narrowing', () => {
-	let instance: DOMObserver
+	let instance: DOMObserverInstance
 
 	beforeEach(() => {
-		instance = new DOMObserver()
+		instance = createDOMObserver()
 	})
 
 	afterEach(() => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export type {
 	ChangeOptions,
 	ChangePayload,
 	DOMObserverEventValue,
+	DOMObserverInstance,
 	DOMTarget,
 	EventPayload,
 	ExistPayload,
@@ -13,7 +14,7 @@ export type {
 	WaitResult,
 	WatchOptions,
 } from './DOMObserver'
-export { default as DOMObserver, DOMObserverEvent, DOMObserverEvents } from './DOMObserver'
+export { createDOMObserver, DOMObserverEvent, DOMObserverEvents } from './DOMObserver'
 export {
 	InvalidEventsError,
 	InvalidOptionsError,


### PR DESCRIPTION
## Summary

Replaces the `new DOMObserver()` class API with a `createDOMObserver()` factory function as the sole public entry point. The `DOMObserver` class is kept as an internal implementation detail but is no longer exported. A new `DOMObserverInstance` interface is exported for TypeScript consumers who need to type their variables.

## Changes

- `src/DOMObserver.ts` — added `DOMObserverInstance` interface, added `createDOMObserver()` factory, removed `export default`
- `src/index.ts` — replaced `DOMObserver` value export with `createDOMObserver` + `DOMObserverInstance` type export
- `src/__tests__/DOMObserver.test.ts` — replaced `new DOMObserver()` with `createDOMObserver()`, updated type annotations
- `dev/src/index.js` — updated demo to use `createDOMObserver()`
- `README.md` — updated all examples, imports, added `DOMObserverInstance` TypeScript section

## ⚠️ Breaking changes

- **`new DOMObserver()`** removed — use `createDOMObserver()` instead
- **`DOMObserver` class** no longer exported — use `DOMObserverInstance` for type annotations
- Migration:
  ```diff
  - import { DOMObserver } from '@untemps/dom-observer'
  - const obs = new DOMObserver()
  + import { createDOMObserver, type DOMObserverInstance } from '@untemps/dom-observer'
  + const obs = createDOMObserver()
  ```

## Test plan

- [ ] `createDOMObserver()` returns a working observer (all 95 tests pass)
- [ ] TypeScript: `DOMObserverInstance` type is importable and usable for variable annotations
- [ ] Demo starts without errors (`yarn dev`)
- [ ] Build produces correct `.d.ts` declarations with `createDOMObserver` and `DOMObserverInstance`

Closes #55