### PR TITLE
feat!: Rename watch/wait/clear to observe/observeOnce/disconnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Calling `disconnect()` after `observeOnce()` resolves is safe and is a no-op. If
 | - `attributeFilter` | Array             | List of attribute names to observe (DOMObserverEvent.CHANGE event only)                                                                                       |
 | - `signal`          | AbortSignal       | An `AbortSignal` to cancel the observation. If already aborted, the Promise rejects immediately with an `AbortError`.                                    |
 | - `root`            | Element or String | DOM element or CSS selector to use as the observation root. Only mutations within this subtree are observed. Defaults to `document.documentElement`.     |
-| - `filter`          | Function          | `(payload: EventPayload) => boolean`. Called before resolving the Promise. Return `false` to skip the event and keep waiting.                                 |
+| - `filter`          | Function          | `(payload: EventPayload) => boolean`. Called before resolving the Promise. Return `false` to skip the event and keep observing.                                 |
 
 #### Resolved value
 
@@ -249,6 +249,9 @@ Call the `disconnect()` method to stop the active observation. It returns `this`
 
 ```javascript
 const instance = createDOMObserver()
+instance.observe('#foo', onEvent)
+
+// Stop observation
 instance.disconnect()
 
 // Stop and immediately restart with a different target

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Unlike `observeOnce`, `observe` does not return a Promise. It returns `this`, al
 Pass `once: true` to stop the observation automatically after the first matching event, without needing to call `disconnect()` manually:
 
 ```javascript
+const instance = createDOMObserver()
 instance.observe('#foo', ({ node }) => {
 	doSomething(node)  // called exactly once
 }, { events: [DOMObserverEvent.ADD], once: true })
@@ -63,6 +64,7 @@ instance.observe('#foo', ({ node }) => {
 Pass `debounce` to delay the callback until mutations have stopped for a given number of milliseconds — useful when you only care about the final state after a burst of rapid changes:
 
 ```javascript
+const instance = createDOMObserver()
 instance.observe('#progress', ({ node }) => {
 	console.log('final value:', node.getAttribute('data-value'))
 }, {
@@ -107,6 +109,7 @@ instance.observe('#foo', ({ node, event }) => {
 The callback receives a single `EventPayload` object — a **discriminated union** on `event`. Narrow on `event` to access `options` without optional chaining:
 
 ```typescript
+const instance = createDOMObserver()
 instance.observe('#foo', ({ event, node, options }) => {
 	if (event === DOMObserverEvent.CHANGE) {
 		console.log(options.attributeName) // ✅ ChangeOptions — never undefined here
@@ -153,6 +156,7 @@ switch (result.event) {
 Pass an **array of targets** to resolve as soon as any one of them fires a matching event. The resolved value includes a `target` field identifying which entry won:
 
 ```javascript
+const instance = createDOMObserver()
 const { node, target } = await instance.observeOnce(['#success', '#error'], {
 	events: [DOMObserverEvent.ADD],
 })
@@ -205,7 +209,7 @@ All observable event constants are exported from the `DOMObserverEvent` object.
 | `DOMObserverEvent.CHANGE` | Observe when an attribute has changed on the element                                      |
 | `DOMObserverEvents` | Array of all four events                                                                  |
 
-One or more events can be passed to the `events` option of `wait` or `watch`. By default, all events are observed.
+One or more events can be passed to the `events` option of `observeOnce()` or `observe()`. By default, all events are observed.
 
 ```javascript
 { events: [DOMObserverEvent.ADD, DOMObserverEvent.REMOVE] }
@@ -234,7 +238,7 @@ import { createDOMObserver, type DOMObserverInstance } from '@untemps/dom-observ
 let instance: DOMObserverInstance
 
 function setup() {
-    observer = createDOMObserver()
+    instance = createDOMObserver()
     instance.observe('#foo', ({ node }) => doSomething(node))
 }
 ```
@@ -244,6 +248,7 @@ function setup() {
 Call the `disconnect()` method to stop the active observation. It returns `this`, allowing method chaining:
 
 ```javascript
+const instance = createDOMObserver()
 instance.disconnect()
 
 // Stop and immediately restart with a different target

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ import { createDOMObserver, DOMObserverEvent } from '@untemps/dom-observer'
 Create an observer instance:
 
 ```javascript
-const observer = createDOMObserver()
+const instance = createDOMObserver()
 ```
 
 ### Observe recurring mutations
@@ -37,14 +37,14 @@ Use the `observe()` method when you want to be notified **every time** a mutatio
 import { createDOMObserver, DOMObserverEvent } from '@untemps/dom-observer'
 
 // Track every attribute change on an element
-const observer = createDOMObserver()
-observer.observe('#foo', ({ node, options }) => {
+const instance = createDOMObserver()
+instance.observe('#foo', ({ node, options }) => {
 	console.log(`${options?.attributeName} changed from ${options?.oldValue} to ${node.getAttribute(options?.attributeName ?? '')}`)
 }, { events: [DOMObserverEvent.CHANGE] })
 
 // React to every matching node added or removed
-const listObserver = createDOMObserver()
-listObserver.observe('.list-item', ({ node, event }) => {
+const listInstance = createDOMObserver()
+listInstance.observe('.list-item', ({ node, event }) => {
 	if (event === DOMObserverEvent.ADD) console.log(`Item added: ${node.textContent}`)
 	if (event === DOMObserverEvent.REMOVE) console.log(`Item removed: ${node.textContent}`)
 }, { events: [DOMObserverEvent.ADD, DOMObserverEvent.REMOVE] })
@@ -55,7 +55,7 @@ Unlike `observeOnce`, `observe` does not return a Promise. It returns `this`, al
 Pass `once: true` to stop the observation automatically after the first matching event, without needing to call `disconnect()` manually:
 
 ```javascript
-observer.observe('#foo', ({ node }) => {
+instance.observe('#foo', ({ node }) => {
 	doSomething(node)  // called exactly once
 }, { events: [DOMObserverEvent.ADD], once: true })
 ```
@@ -63,7 +63,7 @@ observer.observe('#foo', ({ node }) => {
 Pass `debounce` to delay the callback until mutations have stopped for a given number of milliseconds — useful when you only care about the final state after a burst of rapid changes:
 
 ```javascript
-observer.observe('#progress', ({ node }) => {
+instance.observe('#progress', ({ node }) => {
 	console.log('final value:', node.getAttribute('data-value'))
 }, {
 	events: [DOMObserverEvent.CHANGE],
@@ -75,8 +75,8 @@ observer.observe('#progress', ({ node }) => {
 Pass a `timeout` to automatically stop the observation if no matching mutation occurs within the allotted time:
 
 ```javascript
-const observer = createDOMObserver()
-observer.observe('#foo', ({ node, event }) => {
+const instance = createDOMObserver()
+instance.observe('#foo', ({ node, event }) => {
 	console.log(`Event: ${event}`)
 }, {
 	events: [DOMObserverEvent.ADD],
@@ -107,7 +107,7 @@ observer.observe('#foo', ({ node, event }) => {
 The callback receives a single `EventPayload` object — a **discriminated union** on `event`. Narrow on `event` to access `options` without optional chaining:
 
 ```typescript
-observer.observe('#foo', ({ event, node, options }) => {
+instance.observe('#foo', ({ event, node, options }) => {
 	if (event === DOMObserverEvent.CHANGE) {
 		console.log(options.attributeName) // ✅ ChangeOptions — never undefined here
 	}
@@ -135,8 +135,8 @@ Use the `observeOnce()` method to get a Promise that resolves on the **first** m
 ```javascript
 import { createDOMObserver, DOMObserverEvent } from '@untemps/dom-observer'
 
-const observer = createDOMObserver()
-const result = await observer.observeOnce('#foo', { events: [DOMObserverEvent.REMOVE, DOMObserverEvent.CHANGE] })
+const instance = createDOMObserver()
+const result = await instance.observeOnce('#foo', { events: [DOMObserverEvent.REMOVE, DOMObserverEvent.CHANGE] })
 switch (result.event) {
 	case DOMObserverEvent.REMOVE: {
 		console.log('Element ' + result.node.id + ' has been removed')
@@ -153,7 +153,7 @@ switch (result.event) {
 Pass an **array of targets** to resolve as soon as any one of them fires a matching event. The resolved value includes a `target` field identifying which entry won:
 
 ```javascript
-const { node, target } = await observer.observeOnce(['#success', '#error'], {
+const { node, target } = await instance.observeOnce(['#success', '#error'], {
 	events: [DOMObserverEvent.ADD],
 })
 console.log(`Matched: ${target}`)
@@ -162,9 +162,9 @@ console.log(`Matched: ${target}`)
 Once the first matching mutation occurs, the Promise resolves and the observation stops automatically — the internal observer is disconnected and all state is reset before the Promise settles. `isObserving` is `false` immediately after `await`:
 
 ```javascript
-const observer = createDOMObserver()
-const { node } = await observer.observeOnce('#foo')
-console.log(observer.isObserving) // false — auto-cleared on resolution
+const instance = createDOMObserver()
+const { node } = await instance.observeOnce('#foo')
+console.log(instance.isObserving) // false — auto-cleared on resolution
 ```
 
 Calling `disconnect()` after `observeOnce()` resolves is safe and is a no-op. If a `timeout` is set and elapses before any matching mutation, the Promise rejects with a `TimeoutError`.
@@ -217,11 +217,11 @@ One or more events can be passed to the `events` option of `wait` or `watch`. By
 The `isObserving` getter returns `true` when an observation is currently active:
 
 ```javascript
-const observer = createDOMObserver()
-observer.observe('#foo', ({ node, event }) => { /* ... */ })
-console.log(observer.isObserving) // true
-observer.disconnect()
-console.log(observer.isObserving) // false
+const instance = createDOMObserver()
+instance.observe('#foo', ({ node, event }) => { /* ... */ })
+console.log(instance.isObserving) // true
+instance.disconnect()
+console.log(instance.isObserving) // false
 ```
 
 ### TypeScript: typing observer instances
@@ -231,11 +231,11 @@ Use the exported `DOMObserverInstance` type to annotate variables that hold an o
 ```typescript
 import { createDOMObserver, type DOMObserverInstance } from '@untemps/dom-observer'
 
-let observer: DOMObserverInstance
+let instance: DOMObserverInstance
 
 function setup() {
     observer = createDOMObserver()
-    observer.observe('#foo', ({ node }) => doSomething(node))
+    instance.observe('#foo', ({ node }) => doSomething(node))
 }
 ```
 
@@ -244,10 +244,10 @@ function setup() {
 Call the `disconnect()` method to stop the active observation. It returns `this`, allowing method chaining:
 
 ```javascript
-observer.disconnect()
+instance.disconnect()
 
 // Stop and immediately restart with a different target
-observer.disconnect().observe('#bar', onEvent)
+instance.disconnect().observe('#bar', onEvent)
 ```
 
 > **Note:** Calling `observeOnce()` or `observe()` on an instance that already has a pending `observeOnce()` Promise will automatically reject that Promise with an `ObservationAbortedError` before starting the new observation. Handle this rejection if necessary:
@@ -255,13 +255,13 @@ observer.disconnect().observe('#bar', onEvent)
 > ```javascript
 > import { createDOMObserver, ObservationAbortedError } from '@untemps/dom-observer'
 >
-> const observer = createDOMObserver()
-> observer.observeOnce('#foo').catch((err) => {
+> const instance = createDOMObserver()
+> instance.observeOnce('#foo').catch((err) => {
 >     if (err instanceof ObservationAbortedError) return // replaced by a new observation
 >     throw err
 > })
-> observer.observeOnce('#bar')  // previous promise is rejected with ObservationAbortedError
-> observer.observe('#baz', onEvent)  // also rejects a pending wait() with ObservationAbortedError
+> instance.observeOnce('#bar')  // previous promise is rejected with ObservationAbortedError
+> instance.observe('#baz', onEvent)  // also rejects a pending observeOnce() promise with ObservationAbortedError
 > ```
 
 ## Error classes
@@ -271,9 +271,9 @@ The library exports typed `Error` subclasses for reliable error handling with `i
 ```typescript
 import { createDOMObserver, DOMObserverEvent, TimeoutError, ObservationAbortedError } from '@untemps/dom-observer'
 
-const observer = createDOMObserver()
+const instance = createDOMObserver()
 try {
-    await observer.observeOnce('#foo', { timeout: 500 })
+    await instance.observeOnce('#foo', { timeout: 500 })
 } catch (e) {
     if (e instanceof TimeoutError) {
         console.log(`Timed out waiting for ${e.target} after ${e.timeout}ms`)
@@ -299,8 +299,8 @@ import { createDOMObserver, DOMObserverEvent } from '@untemps/dom-observer'
 
 // Continuous observation with timeout
 const onError = (err) => console.error(err.message)
-const observer = createDOMObserver()
-observer.observe(
+const instance = createDOMObserver()
+instance.observe(
     '.foo',
     ({ node, event, options }) => {
         switch (event) {

--- a/README.md
+++ b/README.md
@@ -29,33 +29,33 @@ Create an observer instance:
 const observer = createDOMObserver()
 ```
 
-### Watch for recurring mutations
+### Observe recurring mutations
 
-Use the `watch` method when you want to be notified **every time** a mutation occurs — for instance, tracking all successive attribute changes on an element or reacting to every matching node added to the DOM.
+Use the `observe()` method when you want to be notified **every time** a mutation occurs — for instance, tracking all successive attribute changes on an element or reacting to every matching node added to the DOM.
 
 ```javascript
 import { createDOMObserver, DOMObserverEvent } from '@untemps/dom-observer'
 
 // Track every attribute change on an element
 const observer = createDOMObserver()
-observer.watch('#foo', ({ node, options }) => {
+observer.observe('#foo', ({ node, options }) => {
 	console.log(`${options?.attributeName} changed from ${options?.oldValue} to ${node.getAttribute(options?.attributeName ?? '')}`)
 }, { events: [DOMObserverEvent.CHANGE] })
 
 // React to every matching node added or removed
 const listObserver = createDOMObserver()
-listObserver.watch('.list-item', ({ node, event }) => {
+listObserver.observe('.list-item', ({ node, event }) => {
 	if (event === DOMObserverEvent.ADD) console.log(`Item added: ${node.textContent}`)
 	if (event === DOMObserverEvent.REMOVE) console.log(`Item removed: ${node.textContent}`)
 }, { events: [DOMObserverEvent.ADD, DOMObserverEvent.REMOVE] })
 ```
 
-Unlike `wait`, `watch` does not return a Promise. It returns `this`, allowing method chaining. Call `clear()` to stop the observation.
+Unlike `observeOnce`, `observe` does not return a Promise. It returns `this`, allowing method chaining. Call `disconnect()` to stop the observation.
 
-Pass `once: true` to stop the observation automatically after the first matching event, without needing to call `clear()` manually:
+Pass `once: true` to stop the observation automatically after the first matching event, without needing to call `disconnect()` manually:
 
 ```javascript
-observer.watch('#foo', ({ node }) => {
+observer.observe('#foo', ({ node }) => {
 	doSomething(node)  // called exactly once
 }, { events: [DOMObserverEvent.ADD], once: true })
 ```
@@ -63,7 +63,7 @@ observer.watch('#foo', ({ node }) => {
 Pass `debounce` to delay the callback until mutations have stopped for a given number of milliseconds — useful when you only care about the final state after a burst of rapid changes:
 
 ```javascript
-observer.watch('#progress', ({ node }) => {
+observer.observe('#progress', ({ node }) => {
 	console.log('final value:', node.getAttribute('data-value'))
 }, {
 	events: [DOMObserverEvent.CHANGE],
@@ -76,7 +76,7 @@ Pass a `timeout` to automatically stop the observation if no matching mutation o
 
 ```javascript
 const observer = createDOMObserver()
-observer.watch('#foo', ({ node, event }) => {
+observer.observe('#foo', ({ node, event }) => {
 	console.log(`Event: ${event}`)
 }, {
 	events: [DOMObserverEvent.ADD],
@@ -85,7 +85,7 @@ observer.watch('#foo', ({ node, event }) => {
 })
 ```
 
-#### `watch` method arguments
+#### `observe` method arguments
 
 | Props               | Type              | Description                                                                                                                                              |
 | ------------------- | ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -96,8 +96,8 @@ observer.watch('#foo', ({ node, event }) => {
 | - `attributeFilter` | Array             | List of attribute names to observe (DOMObserverEvent.CHANGE event only)                                                                                       |
 | - `timeout`         | Number            | Duration (in ms) after which observation stops if no matching mutation occurred. Triggers `onError` with a `TimeoutError` when elapsed. Must be `0` or a positive finite number — throws `InvalidTimeoutError` otherwise. |
 | - `onError`         | Function          | Callback triggered when `timeout` elapses with no matching mutation                                                                                      |
-| - `signal`          | AbortSignal       | An `AbortSignal` to stop the observation. If already aborted, `watch()` returns immediately without observing.                                           |
-| - `once`            | Boolean           | When `true`, automatically calls `clear()` after the first matching event. Defaults to `false`.                                                          |
+| - `signal`          | AbortSignal       | An `AbortSignal` to stop the observation. If already aborted, `observe()` returns immediately without observing.                                           |
+| - `once`            | Boolean           | When `true`, automatically calls `disconnect()` after the first matching event. Defaults to `false`.                                                          |
 | - `debounce`        | Number            | Milliseconds to wait after the last mutation before invoking the callback. The callback receives the last mutation's arguments. `0` disables debouncing. |
 | - `root`            | Element or String | DOM element or CSS selector to use as the observation root. Only mutations within this subtree are observed. Defaults to `document.documentElement`.     |
 | - `filter`          | Function          | `(payload: EventPayload) => boolean`. Called before invoking the callback. Return `false` to skip the event and keep observing.                               |
@@ -107,7 +107,7 @@ observer.watch('#foo', ({ node, event }) => {
 The callback receives a single `EventPayload` object — a **discriminated union** on `event`. Narrow on `event` to access `options` without optional chaining:
 
 ```typescript
-observer.watch('#foo', ({ event, node, options }) => {
+observer.observe('#foo', ({ event, node, options }) => {
 	if (event === DOMObserverEvent.CHANGE) {
 		console.log(options.attributeName) // ✅ ChangeOptions — never undefined here
 	}
@@ -128,15 +128,15 @@ observer.watch('#foo', ({ event, node, options }) => {
 | ------- | ----- | ------------ |
 | `error` | Error | Error thrown |
 
-### Wait for a one-shot mutation
+### Observe a one-shot mutation
 
-Use the `wait` method to get a Promise that resolves on the **first** matching mutation.
+Use the `observeOnce()` method to get a Promise that resolves on the **first** matching mutation.
 
 ```javascript
 import { createDOMObserver, DOMObserverEvent } from '@untemps/dom-observer'
 
 const observer = createDOMObserver()
-const result = await observer.wait('#foo', { events: [DOMObserverEvent.REMOVE, DOMObserverEvent.CHANGE] })
+const result = await observer.observeOnce('#foo', { events: [DOMObserverEvent.REMOVE, DOMObserverEvent.CHANGE] })
 switch (result.event) {
 	case DOMObserverEvent.REMOVE: {
 		console.log('Element ' + result.node.id + ' has been removed')
@@ -153,7 +153,7 @@ switch (result.event) {
 Pass an **array of targets** to resolve as soon as any one of them fires a matching event. The resolved value includes a `target` field identifying which entry won:
 
 ```javascript
-const { node, target } = await observer.wait(['#success', '#error'], {
+const { node, target } = await observer.observeOnce(['#success', '#error'], {
 	events: [DOMObserverEvent.ADD],
 })
 console.log(`Matched: ${target}`)
@@ -163,13 +163,13 @@ Once the first matching mutation occurs, the Promise resolves and the observatio
 
 ```javascript
 const observer = createDOMObserver()
-const { node } = await observer.wait('#foo')
+const { node } = await observer.observeOnce('#foo')
 console.log(observer.isObserving) // false — auto-cleared on resolution
 ```
 
-Calling `clear()` after `wait()` resolves is safe and is a no-op. If a `timeout` is set and elapses before any matching mutation, the Promise rejects with a `TimeoutError`.
+Calling `disconnect()` after `observeOnce()` resolves is safe and is a no-op. If a `timeout` is set and elapses before any matching mutation, the Promise rejects with a `TimeoutError`.
 
-#### `wait` method arguments
+#### `observeOnce` method arguments
 
 | Props               | Type                       | Description                                                                                                                                              |
 | ------------------- | -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -218,9 +218,9 @@ The `isObserving` getter returns `true` when an observation is currently active:
 
 ```javascript
 const observer = createDOMObserver()
-observer.watch('#foo', ({ node, event }) => { /* ... */ })
+observer.observe('#foo', ({ node, event }) => { /* ... */ })
 console.log(observer.isObserving) // true
-observer.clear()
+observer.disconnect()
 console.log(observer.isObserving) // false
 ```
 
@@ -235,33 +235,33 @@ let observer: DOMObserverInstance
 
 function setup() {
     observer = createDOMObserver()
-    observer.watch('#foo', ({ node }) => doSomething(node))
+    observer.observe('#foo', ({ node }) => doSomething(node))
 }
 ```
 
 ### Discard observation
 
-Call the `clear` method to discard observation. It returns `this`, allowing method chaining:
+Call the `disconnect()` method to stop the active observation. It returns `this`, allowing method chaining:
 
 ```javascript
-observer.clear()
+observer.disconnect()
 
 // Stop and immediately restart with a different target
-observer.clear().watch('#bar', onEvent)
+observer.disconnect().observe('#bar', onEvent)
 ```
 
-> **Note:** Calling `wait()` or `watch()` on an instance that already has a pending `wait()` Promise will automatically reject that Promise with an `ObservationAbortedError` before starting the new observation. Handle this rejection if necessary:
+> **Note:** Calling `observeOnce()` or `observe()` on an instance that already has a pending `observeOnce()` Promise will automatically reject that Promise with an `ObservationAbortedError` before starting the new observation. Handle this rejection if necessary:
 >
 > ```javascript
 > import { createDOMObserver, ObservationAbortedError } from '@untemps/dom-observer'
 >
 > const observer = createDOMObserver()
-> observer.wait('#foo').catch((err) => {
+> observer.observeOnce('#foo').catch((err) => {
 >     if (err instanceof ObservationAbortedError) return // replaced by a new observation
 >     throw err
 > })
-> observer.wait('#bar')  // previous promise is rejected with ObservationAbortedError
-> observer.watch('#baz', onEvent)  // also rejects a pending wait() with ObservationAbortedError
+> observer.observeOnce('#bar')  // previous promise is rejected with ObservationAbortedError
+> observer.observe('#baz', onEvent)  // also rejects a pending wait() with ObservationAbortedError
 > ```
 
 ## Error classes
@@ -273,7 +273,7 @@ import { createDOMObserver, DOMObserverEvent, TimeoutError, ObservationAbortedEr
 
 const observer = createDOMObserver()
 try {
-    await observer.wait('#foo', { timeout: 500 })
+    await observer.observeOnce('#foo', { timeout: 500 })
 } catch (e) {
     if (e instanceof TimeoutError) {
         console.log(`Timed out waiting for ${e.target} after ${e.timeout}ms`)
@@ -285,12 +285,12 @@ try {
 
 | Class | Properties | Thrown by |
 |---|---|---|
-| `TimeoutError` | `target: DOMTarget \| DOMTarget[]`, `timeout: number` | `wait()`, `watch()` when `timeout` elapses |
-| `ObservationAbortedError` | — | `wait()` when replaced by a new call |
-| `InvalidEventsError` | — | `wait()`, `watch()` when `events` array is empty |
-| `InvalidTargetError` | `selector: string` | `wait()`, `watch()` when `target` is an invalid CSS selector |
+| `TimeoutError` | `target: DOMTarget \| DOMTarget[]`, `timeout: number` | `observeOnce()`, `observe()` when `timeout` elapses |
+| `ObservationAbortedError` | — | `observeOnce()` when replaced by a new call |
+| `InvalidEventsError` | — | `observeOnce()`, `observe()` when `events` array is empty |
+| `InvalidTargetError` | `selector: string` | `observeOnce()`, `observe()` when `target` is an invalid CSS selector |
 | `InvalidOptionsError` | — | Base class for all invalid-option errors; catch-all via `instanceof` |
-| `InvalidTimeoutError` | — | `wait()`, `watch()` when `timeout` is an invalid value (negative, `NaN`, `Infinity`); extends `InvalidOptionsError` |
+| `InvalidTimeoutError` | — | `observeOnce()`, `observe()` when `timeout` is an invalid value (negative, `NaN`, `Infinity`); extends `InvalidOptionsError` |
 
 ## Example
 
@@ -300,7 +300,7 @@ import { createDOMObserver, DOMObserverEvent } from '@untemps/dom-observer'
 // Continuous observation with timeout
 const onError = (err) => console.error(err.message)
 const observer = createDOMObserver()
-observer.watch(
+observer.observe(
     '.foo',
     ({ node, event, options }) => {
         switch (event) {

--- a/dev/src/index.js
+++ b/dev/src/index.js
@@ -46,23 +46,23 @@ const onEvent = ({ node, event, options }) => {
 const tooltipObserver = createDOMObserver()
 tooltipObserver.observe(tooltip, onEvent, { events: [DOMObserverEvent.ADD, DOMObserverEvent.REMOVE] })
 
-const watchCard = () => {
+const observeCard = () => {
 	createDOMObserver()
 		.observeOnce(`#card`)
 		.then(({ node }) => {
 			log(`[ADD]\t\tElement id: ${node.id}`)
-			const cardWatcher = createDOMObserver()
-			cardWatcher.observe(
+			const cardObserver = createDOMObserver()
+			cardObserver.observe(
 				`#card`,
 				(payload) => {
 					onEvent(payload)
 					if (payload.event === DOMObserverEvent.REMOVE) {
-						cardWatcher.disconnect()
-						watchCard()
+						cardObserver.disconnect()
+						observeCard()
 					}
 				},
 				{ events: [DOMObserverEvent.REMOVE, DOMObserverEvent.CHANGE] }
 			)
 		})
 }
-watchCard()
+observeCard()

--- a/dev/src/index.js
+++ b/dev/src/index.js
@@ -44,20 +44,20 @@ const onEvent = ({ node, event, options }) => {
 }
 
 const tooltipObserver = createDOMObserver()
-tooltipObserver.watch(tooltip, onEvent, { events: [DOMObserverEvent.ADD, DOMObserverEvent.REMOVE] })
+tooltipObserver.observe(tooltip, onEvent, { events: [DOMObserverEvent.ADD, DOMObserverEvent.REMOVE] })
 
 const watchCard = () => {
 	createDOMObserver()
-		.wait(`#card`)
+		.observeOnce(`#card`)
 		.then(({ node }) => {
 			log(`[ADD]\t\tElement id: ${node.id}`)
 			const cardWatcher = createDOMObserver()
-			cardWatcher.watch(
+			cardWatcher.observe(
 				`#card`,
 				(payload) => {
 					onEvent(payload)
 					if (payload.event === DOMObserverEvent.REMOVE) {
-						cardWatcher.clear()
+						cardWatcher.disconnect()
 						watchCard()
 					}
 				},

--- a/src/DOMObserver.ts
+++ b/src/DOMObserver.ts
@@ -79,7 +79,7 @@ export interface ChangePayload {
  *
  * @example
  * ```typescript
- * obs.watch('#foo', ({ event, node, options }) => {
+ * obs.observe('#foo', ({ event, node, options }) => {
  *   if (event === DOMObserverEvent.CHANGE) {
  *     console.log(options.attributeName) // ✅ ChangeOptions — not undefined
  *   }
@@ -89,7 +89,7 @@ export interface ChangePayload {
 export type EventPayload = ExistPayload | AddPayload | RemovePayload | ChangePayload
 
 /**
- * Callback invoked by `watch()` whenever an observed event occurs.
+ * Callback invoked by `observe()` whenever an observed event occurs.
  *
  * @param payload - Discriminated union narrowed by `event`.
  */
@@ -101,14 +101,14 @@ export type OnEventCallback = (payload: EventPayload) => void
  */
 export type FilterCallback = (payload: EventPayload) => boolean
 
-/** Resolved value of the Promise returned by `wait()`. */
-export type WaitResult = EventPayload & {
-	/** The target entry that triggered the match. Only populated when `wait()` was called with an array of targets. */
+/** Resolved value of the Promise returned by `observeOnce()`. */
+export type ObserveOnceResult = EventPayload & {
+	/** The target entry that triggered the match. Only populated when `observeOnce()` was called with an array of targets. */
 	target?: DOMTarget
 }
 
-/** Options accepted by `wait()`. */
-export interface WaitOptions {
+/** Options accepted by `observeOnce()`. */
+export interface ObserveOnceOptions {
 	/** Event types to listen for. Defaults to all four event types. */
 	events?: readonly DOMObserverEventValue[]
 	/** Maximum time in milliseconds to wait before rejecting with a `TimeoutError`. `0` disables the timeout. Must be `0` or a positive finite number — rejects with `InvalidTimeoutError` otherwise. */
@@ -123,8 +123,8 @@ export interface WaitOptions {
 	filter?: FilterCallback
 }
 
-/** Options accepted by `watch()`. */
-export interface WatchOptions {
+/** Options accepted by `observe()`. */
+export interface ObserveOptions {
 	/** Event types to listen for. Defaults to all four event types. */
 	events?: readonly DOMObserverEventValue[]
 	/** Restrict attribute observation to these attribute names. Passed directly to `MutationObserver.observe()`. */
@@ -139,7 +139,7 @@ export interface WatchOptions {
 	onError?: (error: Error) => void
 	/** When provided, aborting the signal stops observation immediately. */
 	signal?: AbortSignal
-	/** When `true`, automatically calls `clear()` after the first matching event. */
+	/** When `true`, automatically calls `disconnect()` after the first matching event. */
 	once?: boolean
 	/** Milliseconds to wait after the last mutation before invoking the callback. The callback receives the last mutation's arguments. `0` disables debouncing. */
 	debounce?: number
@@ -154,12 +154,12 @@ export interface WatchOptions {
 
 /** Public interface of the observer instance returned by `createDOMObserver()`. */
 export interface DOMObserverInstance {
-	/** `true` while an observation is active, `false` after `clear()` is called or the observation settles. */
+	/** `true` while an observation is active, `false` after `disconnect()` is called or the observation settles. */
 	readonly isObserving: boolean
-	wait(target: DOMTarget, options?: WaitOptions): Promise<WaitResult>
-	wait(targets: DOMTarget[], options?: WaitOptions): Promise<WaitResult>
-	watch(target: DOMTarget, onEvent: OnEventCallback, options?: WatchOptions): this
-	clear(): this
+	observeOnce(target: DOMTarget, options?: ObserveOnceOptions): Promise<ObserveOnceResult>
+	observeOnce(targets: DOMTarget[], options?: ObserveOnceOptions): Promise<ObserveOnceResult>
+	observe(target: DOMTarget, onEvent: OnEventCallback, options?: ObserveOptions): this
+	disconnect(): this
 }
 
 class DOMObserver implements DOMObserverInstance {
@@ -170,7 +170,7 @@ class DOMObserver implements DOMObserverInstance {
 	private _timeout: ReturnType<typeof setTimeout> | undefined = undefined
 	private _debounceTimer: ReturnType<typeof setTimeout> | undefined = undefined
 
-	/** `true` while an observation is active, `false` after `clear()` is called or the observation settles. */
+	/** `true` while an observation is active, `false` after `disconnect()` is called or the observation settles. */
 	get isObserving(): boolean {
 		return this._observer !== null
 	}
@@ -182,11 +182,11 @@ class DOMObserver implements DOMObserverInstance {
 	 * resolves synchronously on the next microtask. The observer is automatically disconnected as soon
 	 * as the Promise settles — whether by resolution, rejection, timeout, or abort.
 	 *
-	 * Calling `wait()` while a previous call is still pending rejects the previous Promise with `ObservationAbortedError`
+	 * Calling `observeOnce()` while a previous call is still pending rejects the previous Promise with `ObservationAbortedError`
 	 * and starts a fresh observation.
 	 *
 	 * When an array of targets is passed, the Promise resolves as soon as any one of them fires a
-	 * matching event. The resolved `WaitResult.target` identifies which entry won. For EXIST checks,
+	 * matching event. The resolved `ObserveOnceResult.target` identifies which entry won. For EXIST checks,
 	 * the first target found in the DOM wins.
 	 *
 	 * @param target - CSS selector, Element, or array of either to observe.
@@ -196,9 +196,9 @@ class DOMObserver implements DOMObserverInstance {
 	 * @throws `InvalidTimeoutError` when `timeout` is negative, `NaN`, or `Infinity`.
 	 * @throws `InvalidTargetError` when any target string is not a valid CSS selector.
 	 */
-	wait(target: DOMTarget, options?: WaitOptions): Promise<WaitResult>
-	wait(targets: DOMTarget[], options?: WaitOptions): Promise<WaitResult>
-	wait(
+	observeOnce(target: DOMTarget, options?: ObserveOnceOptions): Promise<ObserveOnceResult>
+	observeOnce(targets: DOMTarget[], options?: ObserveOnceOptions): Promise<ObserveOnceResult>
+	observeOnce(
 		target: DOMTarget | DOMTarget[],
 		{
 			events = DOMObserverEvents,
@@ -207,8 +207,8 @@ class DOMObserver implements DOMObserverInstance {
 			signal = undefined,
 			root = undefined,
 			filter = undefined,
-		}: WaitOptions = {}
-	): Promise<WaitResult> {
+		}: ObserveOnceOptions = {}
+	): Promise<ObserveOnceResult> {
 		if (!events?.length) {
 			return Promise.reject(new InvalidEventsError())
 		}
@@ -221,13 +221,13 @@ class DOMObserver implements DOMObserverInstance {
 			return Promise.reject(signal.reason ?? new DOMException('Aborted', 'AbortError'))
 		}
 
-		this._pendingReject?.(new ObservationAbortedError('Observation replaced by a new wait() call'))
+		this._pendingReject?.(new ObservationAbortedError('Observation replaced by a new observeOnce() call'))
 		this._pendingReject = null
-		this.clear()
+		this.disconnect()
 
 		const isMulti = Array.isArray(target)
 
-		return new Promise<WaitResult>((resolve, reject) => {
+		return new Promise<ObserveOnceResult>((resolve, reject) => {
 			let onAbort: (() => void) | null = null
 			let matchedTarget: DOMTarget | undefined
 
@@ -235,9 +235,9 @@ class DOMObserver implements DOMObserverInstance {
 				if (onAbort) signal?.removeEventListener('abort', onAbort)
 				this._pendingReject = null
 			}
-			const settle = (value: WaitResult) => {
+			const settle = (value: ObserveOnceResult) => {
 				cleanup()
-				this.clear()
+				this.disconnect()
 				resolve(value)
 			}
 			const cancel = (error: Error | DOMException) => {
@@ -250,7 +250,11 @@ class DOMObserver implements DOMObserverInstance {
 			// onMatch always fires synchronously before fireCallback in _observe, so matchedTarget
 			// is guaranteed to be set before callback runs.
 			const callback: OnEventCallback = (payload) => {
-				settle(isMulti ? ({ ...payload, target: matchedTarget } as WaitResult) : (payload as WaitResult))
+				settle(
+					isMulti
+						? ({ ...payload, target: matchedTarget } as ObserveOnceResult)
+						: (payload as ObserveOnceResult)
+				)
 			}
 
 			if (signal) {
@@ -266,7 +270,7 @@ class DOMObserver implements DOMObserverInstance {
 				matchedTarget = t
 			})
 		}).finally(() => {
-			this.clear()
+			this.disconnect()
 		})
 	}
 
@@ -276,14 +280,14 @@ class DOMObserver implements DOMObserverInstance {
 	 * If the target already exists in the DOM and `EXIST` is among the requested events, `onEvent` is
 	 * called synchronously before this method returns.
 	 *
-	 * Calling `watch()` while a previous `wait()` is still pending rejects that Promise with `ObservationAbortedError`
+	 * Calling `observe()` while a previous `observeOnce()` is still pending rejects that Promise with `ObservationAbortedError`
 	 * and starts a fresh observation.
 	 *
 	 * When `timeout` is set, the observation stops automatically after the first matching mutation —
 	 * subsequent mutations will not fire `onEvent`.
 	 *
 	 * When `once` is set, the observation stops automatically after the first matching mutation,
-	 * equivalent to calling `clear()` manually inside `onEvent`.
+	 * equivalent to calling `disconnect()` manually inside `onEvent`.
 	 *
 	 * When `debounce` is set, `onEvent` is deferred after each mutation and only fires once the
 	 * mutations have stopped for the specified duration. The callback receives the last mutation's arguments.
@@ -291,12 +295,12 @@ class DOMObserver implements DOMObserverInstance {
 	 * @param target - CSS selector or Element to observe.
 	 * @param onEvent - Callback invoked on every matching event.
 	 * @param options - Observation options.
-	 * @returns The `DOMObserver` instance, allowing method chaining.
+	 * @returns The `DOMObserverInstance`, allowing method chaining.
 	 * @throws `InvalidEventsError` when the `events` array is empty.
 	 * @throws `InvalidTimeoutError` when `timeout` is negative, `NaN`, or `Infinity`.
 	 * @throws `InvalidTargetError` when `target` is a string that is not a valid CSS selector.
 	 */
-	watch(
+	observe(
 		target: DOMTarget,
 		onEvent: OnEventCallback,
 		{
@@ -309,7 +313,7 @@ class DOMObserver implements DOMObserverInstance {
 			debounce = 0,
 			root = undefined,
 			filter = undefined,
-		}: WatchOptions = {}
+		}: ObserveOptions = {}
 	): this {
 		if (!events?.length) {
 			throw new InvalidEventsError()
@@ -323,12 +327,12 @@ class DOMObserver implements DOMObserverInstance {
 			return this
 		}
 
-		this._pendingReject?.(new ObservationAbortedError('Observation replaced by a new watch() call'))
+		this._pendingReject?.(new ObservationAbortedError('Observation replaced by a new observe() call'))
 		this._pendingReject = null
-		this.clear()
+		this.disconnect()
 
 		if (signal) {
-			this._abortHandler = () => this.clear()
+			this._abortHandler = () => this.disconnect()
 			this._signal = signal
 			signal.addEventListener('abort', this._abortHandler, { once: true })
 		}
@@ -341,7 +345,7 @@ class DOMObserver implements DOMObserverInstance {
 				wrapped(payload)
 			}
 			this._timeout = setTimeout(() => {
-				this.clear()
+				this.disconnect()
 				onError?.(new TimeoutError(target, timeout))
 			}, timeout)
 		}
@@ -355,7 +359,7 @@ class DOMObserver implements DOMObserverInstance {
 		if (once) {
 			const wrapped = callback
 			callback = (payload) => {
-				this.clear()
+				this.disconnect()
 				wrapped(payload)
 			}
 		}
@@ -456,7 +460,7 @@ class DOMObserver implements DOMObserverInstance {
 	 *
 	 * @returns The instance, enabling method chaining.
 	 */
-	clear(): this {
+	disconnect(): this {
 		if (this._signal && this._abortHandler) {
 			this._signal.removeEventListener('abort', this._abortHandler)
 		}

--- a/src/DOMObserver.ts
+++ b/src/DOMObserver.ts
@@ -119,7 +119,7 @@ export interface ObserveOnceOptions {
 	signal?: AbortSignal
 	/** DOM element or CSS selector to use as the observation root. Defaults to `document.documentElement`. */
 	root?: DOMTarget
-	/** Predicate applied to every matched node before resolving. Return `false` to skip the event and keep waiting. */
+	/** Predicate applied to every matched node before resolving. Return `false` to skip the event and keep observing. */
 	filter?: FilterCallback
 }
 

--- a/src/__tests__/DOMObserver.test.ts
+++ b/src/__tests__/DOMObserver.test.ts
@@ -534,7 +534,7 @@ describe('createDOMObserver', () => {
 				document.body.appendChild(root)
 				const inside = document.createElement('div')
 				inside.id = 'inside2'
-				instance.observe('#inside2', onEvent, { events: [DOMObserverEvent.ADD], root: '#watch-root' })
+				instance.observe('#inside2', onEvent, { events: [DOMObserverEvent.ADD], root: '#observe-root' })
 				root.appendChild(inside)
 				await _sleep()
 				expect(onEvent).toHaveBeenCalledOnce()

--- a/src/__tests__/DOMObserver.test.ts
+++ b/src/__tests__/DOMObserver.test.ts
@@ -25,7 +25,7 @@ describe('createDOMObserver', () => {
 	})
 
 	afterEach(() => {
-		instance.clear()
+		instance.disconnect()
 
 		document.body.innerHTML = ''
 	})
@@ -37,10 +37,10 @@ describe('createDOMObserver', () => {
 	it('Returns independent instances', () => {
 		const a = createDOMObserver()
 		const b = createDOMObserver()
-		a.watch('#foo', vi.fn())
+		a.observe('#foo', vi.fn())
 		expect(a.isObserving).toBe(true)
 		expect(b.isObserving).toBe(false)
-		a.clear()
+		a.disconnect()
 	})
 
 	describe('wait', () => {
@@ -51,7 +51,7 @@ describe('createDOMObserver', () => {
 				})
 
 				it('Observes an element to be added', async () => {
-					const { node: foundNode, event } = await instance.wait('#foo')
+					const { node: foundNode, event } = await instance.observeOnce('#foo')
 					expect(foundNode).toEqual(node)
 					expect(event).toBe(DOMObserverEvent.EXIST)
 				})
@@ -60,7 +60,7 @@ describe('createDOMObserver', () => {
 					setTimeout(() => {
 						_removeElement('#foo')
 					}, 100)
-					const { node: foundNode, event } = await instance.wait('#foo', {
+					const { node: foundNode, event } = await instance.observeOnce('#foo', {
 						events: [DOMObserverEvent.REMOVE],
 					})
 					expect(foundNode).toEqual(node)
@@ -75,7 +75,7 @@ describe('createDOMObserver', () => {
 						node: foundNode,
 						event,
 						options: { attributeName, oldValue } = {},
-					} = await instance.wait('#foo', {
+					} = await instance.observeOnce('#foo', {
 						events: [DOMObserverEvent.CHANGE],
 					})
 					expect(foundNode).toEqual(node)
@@ -89,7 +89,7 @@ describe('createDOMObserver', () => {
 						_modifyElement('#foo', 'data-ignored', 'x')
 						_modifyElement('#foo', 'data-watched', 'y')
 					}, 50)
-					const { options } = await instance.wait('#foo', {
+					const { options } = await instance.observeOnce('#foo', {
 						events: [DOMObserverEvent.CHANGE],
 						attributeFilter: ['data-watched'],
 					})
@@ -98,18 +98,18 @@ describe('createDOMObserver', () => {
 
 				it('Rejects promise when an element is not found after timeout is elapsed', async () => {
 					await expect(
-						instance.wait('#bar', { events: [DOMObserverEvent.ADD], timeout: 50 })
+						instance.observeOnce('#bar', { events: [DOMObserverEvent.ADD], timeout: 50 })
 					).rejects.toThrow(TimeoutError)
 				})
 
 				it('Rejects the pending promise when wait() is called again', async () => {
-					const first = instance.wait('#bar', { events: [DOMObserverEvent.ADD] })
-					instance.wait('#baz', { events: [DOMObserverEvent.ADD] })
+					const first = instance.observeOnce('#bar', { events: [DOMObserverEvent.ADD] })
+					instance.observeOnce('#baz', { events: [DOMObserverEvent.ADD] })
 					await expect(first).rejects.toThrow(ObservationAbortedError)
 				})
 
 				it('Throws when events array is empty', async () => {
-					await expect(() => instance.wait('#foo', { events: [] })).rejects.toThrow(InvalidEventsError)
+					await expect(() => instance.observeOnce('#foo', { events: [] })).rejects.toThrow(InvalidEventsError)
 				})
 
 				it.each([
@@ -118,28 +118,30 @@ describe('createDOMObserver', () => {
 					[Infinity],
 					[-Infinity],
 				])('Rejects with InvalidTimeoutError when timeout is %s', async (value) => {
-					await expect(instance.wait('#foo', { timeout: value })).rejects.toThrow(InvalidTimeoutError)
+					await expect(instance.observeOnce('#foo', { timeout: value })).rejects.toThrow(InvalidTimeoutError)
 				})
 
 				it('Rejects with InvalidTargetError when selector is invalid', async () => {
-					await expect(instance.wait('##invalid')).rejects.toThrow(InvalidTargetError)
+					await expect(instance.observeOnce('##invalid')).rejects.toThrow(InvalidTargetError)
 				})
 
 				it('Rejects with InvalidTargetError when root selector is invalid', async () => {
-					await expect(instance.wait('#foo', { root: '##invalid' })).rejects.toThrow(InvalidTargetError)
+					await expect(instance.observeOnce('#foo', { root: '##invalid' })).rejects.toThrow(
+						InvalidTargetError
+					)
 				})
 
 				it('Rejects immediately when signal is already aborted', async () => {
 					const controller = new AbortController()
 					controller.abort()
-					await expect(instance.wait('#foo', { signal: controller.signal })).rejects.toMatchObject({
+					await expect(instance.observeOnce('#foo', { signal: controller.signal })).rejects.toMatchObject({
 						name: 'AbortError',
 					})
 				})
 
 				it('Rejects and disconnects when signal is aborted during observation', async () => {
 					const controller = new AbortController()
-					const promise = instance.wait('#bar', {
+					const promise = instance.observeOnce('#bar', {
 						events: [DOMObserverEvent.ADD],
 						signal: controller.signal,
 					})
@@ -148,27 +150,27 @@ describe('createDOMObserver', () => {
 				})
 
 				it('Sets isObserving to false after the promise resolves', async () => {
-					await instance.wait('#foo')
+					await instance.observeOnce('#foo')
 					expect(instance.isObserving).toBe(false)
 				})
 
 				it('Sets isObserving to false synchronously before .then() handler runs', async () => {
 					let observingInThen: boolean | undefined
-					await instance.wait('#foo').then(() => {
+					await instance.observeOnce('#foo').then(() => {
 						observingInThen = instance.isObserving
 					})
 					expect(observingInThen).toBe(false)
 				})
 
 				it('Calling clear() after wait() resolves is a no-op', async () => {
-					await instance.wait('#foo')
-					expect(() => instance.clear()).not.toThrow()
+					await instance.observeOnce('#foo')
+					expect(() => instance.disconnect()).not.toThrow()
 					expect(instance.isObserving).toBe(false)
 				})
 
 				it('Does not clear a subsequent watch() when timeout was set', async () => {
-					await instance.wait('#foo', { timeout: 100 })
-					instance.watch('#foo', vi.fn<OnEventCallback>(), { events: [DOMObserverEvent.CHANGE] })
+					await instance.observeOnce('#foo', { timeout: 100 })
+					instance.observe('#foo', vi.fn<OnEventCallback>(), { events: [DOMObserverEvent.CHANGE] })
 					await _sleep(150)
 					expect(instance.isObserving).toBe(true)
 				})
@@ -181,7 +183,7 @@ describe('createDOMObserver', () => {
 						child.id = 'scoped'
 						root.appendChild(child)
 					}, 50)
-					const { node } = await instance.wait('#scoped', { events: [DOMObserverEvent.ADD], root })
+					const { node } = await instance.observeOnce('#scoped', { events: [DOMObserverEvent.ADD], root })
 					expect(node.id).toBe('scoped')
 					root.remove()
 				})
@@ -195,7 +197,7 @@ describe('createDOMObserver', () => {
 						child.id = 'scoped2'
 						root.appendChild(child)
 					}, 50)
-					const { node } = await instance.wait('#scoped2', {
+					const { node } = await instance.observeOnce('#scoped2', {
 						events: [DOMObserverEvent.ADD],
 						root: '#root-scope',
 					})
@@ -204,7 +206,7 @@ describe('createDOMObserver', () => {
 				})
 
 				it('Resolves immediately when filter passes for an existing element', async () => {
-					const { node: foundNode, event } = await instance.wait('#foo', { filter: () => true })
+					const { node: foundNode, event } = await instance.observeOnce('#foo', { filter: () => true })
 					expect(foundNode).toEqual(node)
 					expect(event).toBe(DOMObserverEvent.EXIST)
 				})
@@ -218,7 +220,7 @@ describe('createDOMObserver', () => {
 						btn.className = 'primary'
 						document.body.appendChild(btn)
 					}, 100)
-					const { node } = await instance.wait('button', {
+					const { node } = await instance.observeOnce('button', {
 						events: [DOMObserverEvent.ADD],
 						filter: ({ node }) => node.classList.contains('primary'),
 					})
@@ -230,7 +232,11 @@ describe('createDOMObserver', () => {
 						document.body.appendChild(document.createElement('button'))
 					}, 30)
 					await expect(
-						instance.wait('button', { events: [DOMObserverEvent.ADD], filter: () => false, timeout: 80 })
+						instance.observeOnce('button', {
+							events: [DOMObserverEvent.ADD],
+							filter: () => false,
+							timeout: 80,
+						})
 					).rejects.toThrow(TimeoutError)
 				})
 
@@ -238,7 +244,7 @@ describe('createDOMObserver', () => {
 					const btn = document.createElement('button')
 					document.body.appendChild(btn)
 					setTimeout(() => btn.setAttribute('data-ready', 'true'), 50)
-					const { node } = await instance.wait('button', {
+					const { node } = await instance.observeOnce('button', {
 						events: [DOMObserverEvent.EXIST, DOMObserverEvent.CHANGE],
 						filter: ({ node }) => node.hasAttribute('data-ready'),
 					})
@@ -249,7 +255,7 @@ describe('createDOMObserver', () => {
 				it('Passes ChangeOptions to filter for CHANGE events', async () => {
 					const filter = vi.fn(() => true)
 					setTimeout(() => _modifyElement('#foo', 'class', 'updated'), 50)
-					await instance.wait('#foo', { events: [DOMObserverEvent.CHANGE], filter })
+					await instance.observeOnce('#foo', { events: [DOMObserverEvent.CHANGE], filter })
 					expect(filter).toHaveBeenCalledWith({
 						node,
 						event: DOMObserverEvent.CHANGE,
@@ -261,7 +267,7 @@ describe('createDOMObserver', () => {
 				})
 
 				it('Leaves result.target undefined for a single-target call', async () => {
-					const { target } = await instance.wait('#foo')
+					const { target } = await instance.observeOnce('#foo')
 					expect(target).toBeUndefined()
 				})
 			})
@@ -271,7 +277,7 @@ describe('createDOMObserver', () => {
 					setTimeout(() => {
 						node = _createElement('foo')
 					}, 100)
-					const { node: foundNode, event } = await instance.wait('#foo')
+					const { node: foundNode, event } = await instance.observeOnce('#foo')
 					expect(foundNode).toEqual(node)
 					expect(event).toBe(DOMObserverEvent.ADD)
 				})
@@ -284,7 +290,7 @@ describe('createDOMObserver', () => {
 			})
 
 			it('Resolves on EXIST for the first target found in the DOM', async () => {
-				const { node: foundNode, event, target } = await instance.wait(['#foo', '#bar'])
+				const { node: foundNode, event, target } = await instance.observeOnce(['#foo', '#bar'])
 				expect(foundNode).toEqual(node)
 				expect(event).toBe(DOMObserverEvent.EXIST)
 				expect(target).toBe('#foo')
@@ -294,7 +300,7 @@ describe('createDOMObserver', () => {
 				const second = document.createElement('div')
 				second.id = 'second'
 				document.body.appendChild(second)
-				const { node, target } = await instance.wait(['#missing', '#second'])
+				const { node, target } = await instance.observeOnce(['#missing', '#second'])
 				expect(node.id).toBe('second')
 				expect(target).toBe('#second')
 				second.remove()
@@ -306,7 +312,9 @@ describe('createDOMObserver', () => {
 					div.id = 'winner'
 					document.body.appendChild(div)
 				}, 50)
-				const { node, target } = await instance.wait(['#winner', '#loser'], { events: [DOMObserverEvent.ADD] })
+				const { node, target } = await instance.observeOnce(['#winner', '#loser'], {
+					events: [DOMObserverEvent.ADD],
+				})
 				expect(node.id).toBe('winner')
 				expect(target).toBe('#winner')
 			})
@@ -317,7 +325,7 @@ describe('createDOMObserver', () => {
 					div.id = 'second-wins'
 					document.body.appendChild(div)
 				}, 50)
-				const { node, target } = await instance.wait(['#first-never', '#second-wins'], {
+				const { node, target } = await instance.observeOnce(['#first-never', '#second-wins'], {
 					events: [DOMObserverEvent.ADD],
 				})
 				expect(node.id).toBe('second-wins')
@@ -325,18 +333,18 @@ describe('createDOMObserver', () => {
 			})
 
 			it('Rejects with InvalidTargetError when any target selector is invalid', async () => {
-				await expect(instance.wait(['#foo', '##invalid'])).rejects.toThrow(InvalidTargetError)
+				await expect(instance.observeOnce(['#foo', '##invalid'])).rejects.toThrow(InvalidTargetError)
 			})
 
 			it('Rejects with TimeoutError when no target matches within the time limit', async () => {
 				await expect(
-					instance.wait(['#missing1', '#missing2'], { events: [DOMObserverEvent.ADD], timeout: 50 })
+					instance.observeOnce(['#missing1', '#missing2'], { events: [DOMObserverEvent.ADD], timeout: 50 })
 				).rejects.toThrow(TimeoutError)
 			})
 
 			it('Rejects with AbortError when signal is aborted during multi-target observation', async () => {
 				const controller = new AbortController()
-				const promise = instance.wait(['#missing1', '#missing2'], {
+				const promise = instance.observeOnce(['#missing1', '#missing2'], {
 					events: [DOMObserverEvent.ADD],
 					signal: controller.signal,
 				})
@@ -349,7 +357,7 @@ describe('createDOMObserver', () => {
 				second.id = 'removable'
 				document.body.appendChild(second)
 				setTimeout(() => second.remove(), 50)
-				const { node, target } = await instance.wait(['#foo', '#removable'], {
+				const { node, target } = await instance.observeOnce(['#foo', '#removable'], {
 					events: [DOMObserverEvent.REMOVE],
 				})
 				expect(node.id).toBe('removable')
@@ -361,7 +369,7 @@ describe('createDOMObserver', () => {
 				second.id = 'changeable'
 				document.body.appendChild(second)
 				setTimeout(() => second.setAttribute('data-x', '1'), 50)
-				const { node, target } = await instance.wait(['#foo', '#changeable'], {
+				const { node, target } = await instance.observeOnce(['#foo', '#changeable'], {
 					events: [DOMObserverEvent.CHANGE],
 				})
 				expect(node.id).toBe('changeable')
@@ -381,7 +389,7 @@ describe('createDOMObserver', () => {
 					div.id = 'filtered-b'
 					document.body.appendChild(div)
 				}, 50)
-				const { node, target } = await instance.wait(['#filtered-a', '#filtered-b'], {
+				const { node, target } = await instance.observeOnce(['#filtered-a', '#filtered-b'], {
 					events: [DOMObserverEvent.ADD],
 					filter: ({ node }) => {
 						callCount++
@@ -406,17 +414,17 @@ describe('createDOMObserver', () => {
 			})
 
 			it('Triggers onEvent immediately with EXIST when element is present', () => {
-				instance.watch('#foo', onEvent)
+				instance.observe('#foo', onEvent)
 				expect(onEvent).toHaveBeenCalledWith({ node, event: DOMObserverEvent.EXIST })
 			})
 
 			it('Accepts an Element reference as target', () => {
-				instance.watch(node, onEvent)
+				instance.observe(node, onEvent)
 				expect(onEvent).toHaveBeenCalledWith({ node, event: DOMObserverEvent.EXIST })
 			})
 
 			it('Triggers onEvent on every successive attribute change', async () => {
-				instance.watch('#foo', onEvent, { events: [DOMObserverEvent.CHANGE] })
+				instance.observe('#foo', onEvent, { events: [DOMObserverEvent.CHANGE] })
 				_modifyElement('#foo', 'class', 'change1')
 				await _sleep()
 				_modifyElement('#foo', 'class', 'change2')
@@ -441,7 +449,7 @@ describe('createDOMObserver', () => {
 			})
 
 			it('Triggers onEvent for each matching added and removed node', async () => {
-				instance.watch('.item', onEvent, { events: [DOMObserverEvent.ADD, DOMObserverEvent.REMOVE] })
+				instance.observe('.item', onEvent, { events: [DOMObserverEvent.ADD, DOMObserverEvent.REMOVE] })
 				const nodeA = _createElementWithClass('item')
 				const nodeB = _createElementWithClass('item')
 				await _sleep()
@@ -457,7 +465,7 @@ describe('createDOMObserver', () => {
 			it('Fires CHANGE for all elements matching a class selector, not just the first', async () => {
 				const nodeA = _createElementWithClass('item')
 				const nodeB = _createElementWithClass('item')
-				instance.watch('.item', onEvent, { events: [DOMObserverEvent.CHANGE] })
+				instance.observe('.item', onEvent, { events: [DOMObserverEvent.CHANGE] })
 				nodeA.setAttribute('data-x', '1')
 				await _sleep()
 				nodeB.setAttribute('data-x', '2')
@@ -476,7 +484,7 @@ describe('createDOMObserver', () => {
 			})
 
 			it('Only fires for attributes in the filter list', async () => {
-				instance.watch('#foo', onEvent, {
+				instance.observe('#foo', onEvent, {
 					events: [DOMObserverEvent.CHANGE],
 					attributeFilter: ['data-watched'],
 				})
@@ -500,7 +508,7 @@ describe('createDOMObserver', () => {
 				document.body.appendChild(root)
 				const inside = document.createElement('div')
 				inside.id = 'inside'
-				instance.watch('#inside', onEvent, { events: [DOMObserverEvent.ADD], root })
+				instance.observe('#inside', onEvent, { events: [DOMObserverEvent.ADD], root })
 				root.appendChild(inside)
 				await _sleep()
 				expect(onEvent).toHaveBeenCalledOnce()
@@ -512,7 +520,7 @@ describe('createDOMObserver', () => {
 				document.body.appendChild(root)
 				const outside = document.createElement('div')
 				outside.id = 'outside'
-				instance.watch('#outside', onEvent, { events: [DOMObserverEvent.ADD], root })
+				instance.observe('#outside', onEvent, { events: [DOMObserverEvent.ADD], root })
 				document.body.appendChild(outside)
 				await _sleep()
 				expect(onEvent).not.toHaveBeenCalled()
@@ -526,7 +534,7 @@ describe('createDOMObserver', () => {
 				document.body.appendChild(root)
 				const inside = document.createElement('div')
 				inside.id = 'inside2'
-				instance.watch('#inside2', onEvent, { events: [DOMObserverEvent.ADD], root: '#watch-root' })
+				instance.observe('#inside2', onEvent, { events: [DOMObserverEvent.ADD], root: '#watch-root' })
 				root.appendChild(inside)
 				await _sleep()
 				expect(onEvent).toHaveBeenCalledOnce()
@@ -534,7 +542,7 @@ describe('createDOMObserver', () => {
 			})
 
 			it('Throws InvalidTargetError when root selector is invalid', () => {
-				expect(() => instance.watch('#foo', onEvent, { root: '##invalid' })).toThrow(InvalidTargetError)
+				expect(() => instance.observe('#foo', onEvent, { root: '##invalid' })).toThrow(InvalidTargetError)
 			})
 
 			it('Respects root when observing CHANGE on an Element reference', async () => {
@@ -544,7 +552,7 @@ describe('createDOMObserver', () => {
 				root.appendChild(watchedNode)
 				const outside = document.createElement('div')
 				document.body.appendChild(outside)
-				instance.watch(watchedNode, onEvent, { events: [DOMObserverEvent.CHANGE], root })
+				instance.observe(watchedNode, onEvent, { events: [DOMObserverEvent.CHANGE], root })
 				outside.setAttribute('data-x', '1')
 				await _sleep()
 				expect(onEvent).not.toHaveBeenCalled()
@@ -556,27 +564,27 @@ describe('createDOMObserver', () => {
 			})
 
 			it('Calls onEvent when filter passes', async () => {
-				instance.watch('#foo', onEvent, { events: [DOMObserverEvent.CHANGE], filter: () => true })
+				instance.observe('#foo', onEvent, { events: [DOMObserverEvent.CHANGE], filter: () => true })
 				_modifyElement('#foo', 'class', 'change1')
 				await _sleep()
 				expect(onEvent).toHaveBeenCalledOnce()
 			})
 
 			it('Does not call onEvent when filter returns false', async () => {
-				instance.watch('#foo', onEvent, { events: [DOMObserverEvent.CHANGE], filter: () => false })
+				instance.observe('#foo', onEvent, { events: [DOMObserverEvent.CHANGE], filter: () => false })
 				_modifyElement('#foo', 'class', 'change1')
 				await _sleep()
 				expect(onEvent).not.toHaveBeenCalled()
 			})
 
 			it('Does not fire EXIST when filter returns false for an existing element', () => {
-				instance.watch('#foo', onEvent, { filter: () => false })
+				instance.observe('#foo', onEvent, { filter: () => false })
 				expect(onEvent).not.toHaveBeenCalled()
 			})
 
 			it('Passes ChangeOptions to filter for CHANGE events', async () => {
 				const filter = vi.fn(() => true)
-				instance.watch('#foo', onEvent, { events: [DOMObserverEvent.CHANGE], filter })
+				instance.observe('#foo', onEvent, { events: [DOMObserverEvent.CHANGE], filter })
 				_modifyElement('#foo', 'class', 'updated')
 				await _sleep()
 				expect(filter).toHaveBeenCalledWith({
@@ -589,7 +597,7 @@ describe('createDOMObserver', () => {
 			it('Does not fire for ADD events rejected by filter', async () => {
 				const inside = document.createElement('div')
 				inside.id = 'allowed'
-				instance.watch('div', onEvent, {
+				instance.observe('div', onEvent, {
 					events: [DOMObserverEvent.ADD],
 					filter: ({ node }) => node.id === 'allowed',
 				})
@@ -603,7 +611,11 @@ describe('createDOMObserver', () => {
 			})
 
 			it('Does not fire once when filter blocks all events', async () => {
-				instance.watch('#foo', onEvent, { events: [DOMObserverEvent.CHANGE], once: true, filter: () => false })
+				instance.observe('#foo', onEvent, {
+					events: [DOMObserverEvent.CHANGE],
+					once: true,
+					filter: () => false,
+				})
 				_modifyElement('#foo', 'class', 'change1')
 				await _sleep()
 				expect(onEvent).not.toHaveBeenCalled()
@@ -611,7 +623,7 @@ describe('createDOMObserver', () => {
 			})
 
 			it('Fires once and stops when filter passes', async () => {
-				instance.watch('#foo', onEvent, { events: [DOMObserverEvent.CHANGE], once: true, filter: () => true })
+				instance.observe('#foo', onEvent, { events: [DOMObserverEvent.CHANGE], once: true, filter: () => true })
 				_modifyElement('#foo', 'class', 'change1')
 				await _sleep()
 				expect(onEvent).toHaveBeenCalledOnce()
@@ -619,7 +631,7 @@ describe('createDOMObserver', () => {
 			})
 
 			it('Throws when events array is empty', () => {
-				expect(() => instance.watch('#foo', onEvent, { events: [] })).toThrow(InvalidEventsError)
+				expect(() => instance.observe('#foo', onEvent, { events: [] })).toThrow(InvalidEventsError)
 			})
 
 			it.each([
@@ -628,35 +640,35 @@ describe('createDOMObserver', () => {
 				[Infinity],
 				[-Infinity],
 			])('Throws InvalidTimeoutError when timeout is %s', (value) => {
-				expect(() => instance.watch('#foo', onEvent, { timeout: value })).toThrow(InvalidTimeoutError)
+				expect(() => instance.observe('#foo', onEvent, { timeout: value })).toThrow(InvalidTimeoutError)
 			})
 
 			it('Throws InvalidTargetError when selector is invalid', () => {
-				expect(() => instance.watch('##invalid', onEvent)).toThrow(InvalidTargetError)
+				expect(() => instance.observe('##invalid', onEvent)).toThrow(InvalidTargetError)
 			})
 
 			it('Rejects the pending wait() promise when watch() is called', async () => {
-				const pending = instance.wait('#bar', { events: [DOMObserverEvent.ADD] })
-				instance.watch('#foo', onEvent)
+				const pending = instance.observeOnce('#bar', { events: [DOMObserverEvent.ADD] })
+				instance.observe('#foo', onEvent)
 				await expect(pending).rejects.toThrow(ObservationAbortedError)
 			})
 
 			it('Returns the instance for chaining', () => {
-				const result = instance.watch('#foo', onEvent)
+				const result = instance.observe('#foo', onEvent)
 				expect(result).toBe(instance)
 			})
 
 			it('Does nothing when signal is already aborted', () => {
 				const controller = new AbortController()
 				controller.abort()
-				instance.watch('#foo', onEvent, { signal: controller.signal })
+				instance.observe('#foo', onEvent, { signal: controller.signal })
 				expect(onEvent).not.toHaveBeenCalled()
 				expect(instance.isObserving).toBe(false)
 			})
 
 			it('Stops observation when signal is aborted', async () => {
 				const controller = new AbortController()
-				instance.watch('#foo', onEvent, { events: [DOMObserverEvent.CHANGE], signal: controller.signal })
+				instance.observe('#foo', onEvent, { events: [DOMObserverEvent.CHANGE], signal: controller.signal })
 				_modifyElement('#foo', 'class', 'change1')
 				await _sleep()
 				expect(onEvent).toHaveBeenCalledTimes(1)
@@ -668,7 +680,7 @@ describe('createDOMObserver', () => {
 
 			it('Calls onError when timeout elapses with no matching mutation', async () => {
 				const onError = vi.fn()
-				instance.watch('#bar', onEvent, { events: [DOMObserverEvent.ADD], timeout: 50, onError })
+				instance.observe('#bar', onEvent, { events: [DOMObserverEvent.ADD], timeout: 50, onError })
 				await _sleep(100)
 				expect(onEvent).not.toHaveBeenCalled()
 				expect(onError).toHaveBeenCalledOnce()
@@ -677,7 +689,7 @@ describe('createDOMObserver', () => {
 
 			it('Does not call onError when a mutation occurs before timeout', async () => {
 				const onError = vi.fn()
-				instance.watch('#foo', onEvent, { events: [DOMObserverEvent.CHANGE], timeout: 200, onError })
+				instance.observe('#foo', onEvent, { events: [DOMObserverEvent.CHANGE], timeout: 200, onError })
 				_modifyElement('#foo', 'class', 'change1')
 				await _sleep()
 				expect(onEvent).toHaveBeenCalledOnce()
@@ -687,13 +699,13 @@ describe('createDOMObserver', () => {
 
 			it('Stops observation after timeout elapses', async () => {
 				const onError = vi.fn()
-				instance.watch('#foo', onEvent, { events: [DOMObserverEvent.CHANGE], timeout: 50, onError })
+				instance.observe('#foo', onEvent, { events: [DOMObserverEvent.CHANGE], timeout: 50, onError })
 				await _sleep(100)
 				expect(instance.isObserving).toBe(false)
 			})
 
 			it('Fires onEvent only once when once is true', async () => {
-				instance.watch('#foo', onEvent, { events: [DOMObserverEvent.CHANGE], once: true })
+				instance.observe('#foo', onEvent, { events: [DOMObserverEvent.CHANGE], once: true })
 				_modifyElement('#foo', 'class', 'change1')
 				await _sleep()
 				_modifyElement('#foo', 'class', 'change2')
@@ -702,7 +714,7 @@ describe('createDOMObserver', () => {
 			})
 
 			it('Sets isObserving to false after the first event when once is true', async () => {
-				instance.watch('#foo', onEvent, { events: [DOMObserverEvent.CHANGE], once: true })
+				instance.observe('#foo', onEvent, { events: [DOMObserverEvent.CHANGE], once: true })
 				_modifyElement('#foo', 'class', 'change1')
 				await _sleep()
 				expect(instance.isObserving).toBe(false)
@@ -710,7 +722,7 @@ describe('createDOMObserver', () => {
 
 			it('Cancels timeout after the first event when once and timeout are both set', async () => {
 				const onError = vi.fn()
-				instance.watch('#foo', onEvent, {
+				instance.observe('#foo', onEvent, {
 					events: [DOMObserverEvent.CHANGE],
 					once: true,
 					timeout: 200,
@@ -724,7 +736,7 @@ describe('createDOMObserver', () => {
 			})
 
 			it('Fires onEvent once after a burst of mutations when debounce is set', async () => {
-				instance.watch('#foo', onEvent, { events: [DOMObserverEvent.CHANGE], debounce: 50 })
+				instance.observe('#foo', onEvent, { events: [DOMObserverEvent.CHANGE], debounce: 50 })
 				_modifyElement('#foo', 'class', 'change1')
 				_modifyElement('#foo', 'class', 'change2')
 				_modifyElement('#foo', 'class', 'change3')
@@ -733,7 +745,7 @@ describe('createDOMObserver', () => {
 			})
 
 			it('Forwards the last mutation arguments when debounce is set', async () => {
-				instance.watch('#foo', onEvent, { events: [DOMObserverEvent.CHANGE], debounce: 50 })
+				instance.observe('#foo', onEvent, { events: [DOMObserverEvent.CHANGE], debounce: 50 })
 				_modifyElement('#foo', 'class', 'change1')
 				_modifyElement('#foo', 'class', 'change2')
 				await _sleep(150)
@@ -748,15 +760,15 @@ describe('createDOMObserver', () => {
 			})
 
 			it('Does not fire onEvent when clear() is called during the debounce period', async () => {
-				instance.watch('#foo', onEvent, { events: [DOMObserverEvent.CHANGE], debounce: 100 })
+				instance.observe('#foo', onEvent, { events: [DOMObserverEvent.CHANGE], debounce: 100 })
 				_modifyElement('#foo', 'class', 'change1')
-				instance.clear()
+				instance.disconnect()
 				await _sleep(200)
 				expect(onEvent).not.toHaveBeenCalled()
 			})
 
 			it('Fires onEvent once and stops when debounce and once are both set', async () => {
-				instance.watch('#foo', onEvent, { events: [DOMObserverEvent.CHANGE], debounce: 50, once: true })
+				instance.observe('#foo', onEvent, { events: [DOMObserverEvent.CHANGE], debounce: 50, once: true })
 				_modifyElement('#foo', 'class', 'change1')
 				_modifyElement('#foo', 'class', 'change2')
 				await _sleep(150)
@@ -766,7 +778,12 @@ describe('createDOMObserver', () => {
 
 			it('Fires onError on timeout when no mutation occurs even with debounce set', async () => {
 				const onError = vi.fn()
-				instance.watch('#bar', onEvent, { events: [DOMObserverEvent.ADD], timeout: 50, debounce: 200, onError })
+				instance.observe('#bar', onEvent, {
+					events: [DOMObserverEvent.ADD],
+					timeout: 50,
+					debounce: 200,
+					onError,
+				})
 				await _sleep(100)
 				expect(onEvent).not.toHaveBeenCalled()
 				expect(onError).toHaveBeenCalledOnce()
@@ -775,7 +792,7 @@ describe('createDOMObserver', () => {
 
 		describe('Element creation and mounting are delayed', () => {
 			it('Triggers onEvent when element is added', async () => {
-				instance.watch('#foo', onEvent)
+				instance.observe('#foo', onEvent)
 				node = _createElement('foo')
 				await _sleep()
 				expect(onEvent).toHaveBeenCalledWith({ node, event: DOMObserverEvent.ADD })
@@ -785,7 +802,7 @@ describe('createDOMObserver', () => {
 
 	describe('clear', () => {
 		it('Returns the instance for chaining', () => {
-			expect(instance.clear()).toBe(instance)
+			expect(instance.disconnect()).toBe(instance)
 		})
 	})
 })
@@ -798,7 +815,7 @@ describe('EventPayload type narrowing', () => {
 	})
 
 	afterEach(() => {
-		instance.clear()
+		instance.disconnect()
 		document.body.innerHTML = ''
 	})
 
@@ -807,7 +824,7 @@ describe('EventPayload type narrowing', () => {
 		setTimeout(() => _modifyElement('#foo', 'data-x', 'new'), 50)
 
 		await new Promise<void>((resolve) => {
-			instance.watch(
+			instance.observe(
 				'#foo',
 				({ event, options }) => {
 					if (event === DOMObserverEvent.CHANGE) {
@@ -824,7 +841,7 @@ describe('EventPayload type narrowing', () => {
 	it('options is absent for non-CHANGE events', async () => {
 		const captured: EventPayload[] = []
 
-		instance.watch('#foo', (payload) => captured.push(payload), { events: [DOMObserverEvent.ADD] })
+		instance.observe('#foo', (payload) => captured.push(payload), { events: [DOMObserverEvent.ADD] })
 
 		_createElement('foo')
 		await _sleep()
@@ -838,7 +855,7 @@ describe('EventPayload type narrowing', () => {
 		_createElement('foo')
 		setTimeout(() => _modifyElement('#foo', 'class', 'updated'), 50)
 
-		const result = await instance.wait('#foo', { events: [DOMObserverEvent.CHANGE] })
+		const result = await instance.observeOnce('#foo', { events: [DOMObserverEvent.CHANGE] })
 
 		expect(result.event).toBe(DOMObserverEvent.CHANGE)
 		if (result.event === DOMObserverEvent.CHANGE) {

--- a/src/__tests__/DOMObserver.test.ts
+++ b/src/__tests__/DOMObserver.test.ts
@@ -87,13 +87,13 @@ describe('createDOMObserver', () => {
 				it('Resolves only when a filtered attribute changes', async () => {
 					setTimeout(() => {
 						_modifyElement('#foo', 'data-ignored', 'x')
-						_modifyElement('#foo', 'data-watched', 'y')
+						_modifyElement('#foo', 'data-observed', 'y')
 					}, 50)
 					const { options } = await instance.observeOnce('#foo', {
 						events: [DOMObserverEvent.CHANGE],
-						attributeFilter: ['data-watched'],
+						attributeFilter: ['data-observed'],
 					})
-					expect(options?.attributeName).toBe('data-watched')
+					expect(options?.attributeName).toBe('data-observed')
 				})
 
 				it('Rejects promise when an element is not found after timeout is elapsed', async () => {
@@ -168,7 +168,7 @@ describe('createDOMObserver', () => {
 					expect(instance.isObserving).toBe(false)
 				})
 
-				it('Does not clear a subsequent watch() when timeout was set', async () => {
+				it('Does not clear a subsequent observe() when timeout was set', async () => {
 					await instance.observeOnce('#foo', { timeout: 100 })
 					instance.observe('#foo', vi.fn<OnEventCallback>(), { events: [DOMObserverEvent.CHANGE] })
 					await _sleep(150)
@@ -403,7 +403,7 @@ describe('createDOMObserver', () => {
 		})
 	})
 
-	describe('watch', () => {
+	describe('observe', () => {
 		beforeEach(() => {
 			onEvent = vi.fn<OnEventCallback>()
 		})
@@ -486,18 +486,18 @@ describe('createDOMObserver', () => {
 			it('Only fires for attributes in the filter list', async () => {
 				instance.observe('#foo', onEvent, {
 					events: [DOMObserverEvent.CHANGE],
-					attributeFilter: ['data-watched'],
+					attributeFilter: ['data-observed'],
 				})
 				_modifyElement('#foo', 'data-ignored', 'x')
 				await _sleep()
-				_modifyElement('#foo', 'data-watched', 'y')
+				_modifyElement('#foo', 'data-observed', 'y')
 				await _sleep()
 				expect(onEvent).toHaveBeenCalledOnce()
 				expect(onEvent).toHaveBeenCalledWith({
 					node,
 					event: DOMObserverEvent.CHANGE,
 					options: {
-						attributeName: 'data-watched',
+						attributeName: 'data-observed',
 						oldValue: null,
 					},
 				})
@@ -530,7 +530,7 @@ describe('createDOMObserver', () => {
 
 			it('Accepts a CSS selector as root', async () => {
 				const root = document.createElement('div')
-				root.id = 'watch-root'
+				root.id = 'observe-root'
 				document.body.appendChild(root)
 				const inside = document.createElement('div')
 				inside.id = 'inside2'
@@ -548,15 +548,15 @@ describe('createDOMObserver', () => {
 			it('Respects root when observing CHANGE on an Element reference', async () => {
 				const root = document.createElement('div')
 				document.body.appendChild(root)
-				const watchedNode = document.createElement('div')
-				root.appendChild(watchedNode)
+				const observedNode = document.createElement('div')
+				root.appendChild(observedNode)
 				const outside = document.createElement('div')
 				document.body.appendChild(outside)
-				instance.observe(watchedNode, onEvent, { events: [DOMObserverEvent.CHANGE], root })
+				instance.observe(observedNode, onEvent, { events: [DOMObserverEvent.CHANGE], root })
 				outside.setAttribute('data-x', '1')
 				await _sleep()
 				expect(onEvent).not.toHaveBeenCalled()
-				watchedNode.setAttribute('data-x', '1')
+				observedNode.setAttribute('data-x', '1')
 				await _sleep()
 				expect(onEvent).toHaveBeenCalledOnce()
 				outside.remove()
@@ -647,7 +647,7 @@ describe('createDOMObserver', () => {
 				expect(() => instance.observe('##invalid', onEvent)).toThrow(InvalidTargetError)
 			})
 
-			it('Rejects the pending wait() promise when watch() is called', async () => {
+			it('Rejects the pending observeOnce() promise when observe() is called', async () => {
 				const pending = instance.observeOnce('#bar', { events: [DOMObserverEvent.ADD] })
 				instance.observe('#foo', onEvent)
 				await expect(pending).rejects.toThrow(ObservationAbortedError)

--- a/src/__tests__/DOMObserver.test.ts
+++ b/src/__tests__/DOMObserver.test.ts
@@ -43,7 +43,7 @@ describe('createDOMObserver', () => {
 		a.disconnect()
 	})
 
-	describe('wait', () => {
+	describe('observeOnce', () => {
 		describe('A promise is resolved as soon as an event occurs', () => {
 			describe('Element is already created and mounted in the DOM', () => {
 				beforeEach(() => {
@@ -102,7 +102,7 @@ describe('createDOMObserver', () => {
 					).rejects.toThrow(TimeoutError)
 				})
 
-				it('Rejects the pending promise when wait() is called again', async () => {
+				it('Rejects the pending promise when observeOnce() is called again', async () => {
 					const first = instance.observeOnce('#bar', { events: [DOMObserverEvent.ADD] })
 					instance.observeOnce('#baz', { events: [DOMObserverEvent.ADD] })
 					await expect(first).rejects.toThrow(ObservationAbortedError)
@@ -162,13 +162,13 @@ describe('createDOMObserver', () => {
 					expect(observingInThen).toBe(false)
 				})
 
-				it('Calling clear() after wait() resolves is a no-op', async () => {
+				it('Calling disconnect() after observeOnce() resolves is a no-op', async () => {
 					await instance.observeOnce('#foo')
 					expect(() => instance.disconnect()).not.toThrow()
 					expect(instance.isObserving).toBe(false)
 				})
 
-				it('Does not clear a subsequent observe() when timeout was set', async () => {
+				it('Does not disconnect a subsequent observe() when timeout was set', async () => {
 					await instance.observeOnce('#foo', { timeout: 100 })
 					instance.observe('#foo', vi.fn<OnEventCallback>(), { events: [DOMObserverEvent.CHANGE] })
 					await _sleep(150)
@@ -759,7 +759,7 @@ describe('createDOMObserver', () => {
 				})
 			})
 
-			it('Does not fire onEvent when clear() is called during the debounce period', async () => {
+			it('Does not fire onEvent when disconnect() is called during the debounce period', async () => {
 				instance.observe('#foo', onEvent, { events: [DOMObserverEvent.CHANGE], debounce: 100 })
 				_modifyElement('#foo', 'class', 'change1')
 				instance.disconnect()
@@ -800,7 +800,7 @@ describe('createDOMObserver', () => {
 		})
 	})
 
-	describe('clear', () => {
+	describe('disconnect', () => {
 		it('Returns the instance for chaining', () => {
 			expect(instance.disconnect()).toBe(instance)
 		})
@@ -851,7 +851,7 @@ describe('EventPayload type narrowing', () => {
 		expect(captured[0].options).toBeUndefined()
 	})
 
-	it('wait() resolves ChangePayload with options typed as ChangeOptions after CHANGE guard', async () => {
+	it('observeOnce() resolves ChangePayload with options typed as ChangeOptions after CHANGE guard', async () => {
 		_createElement('foo')
 		setTimeout(() => _modifyElement('#foo', 'class', 'updated'), 50)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,11 +8,11 @@ export type {
 	EventPayload,
 	ExistPayload,
 	FilterCallback,
+	ObserveOnceOptions,
+	ObserveOnceResult,
+	ObserveOptions,
 	OnEventCallback,
 	RemovePayload,
-	WaitOptions,
-	WaitResult,
-	WatchOptions,
 } from './DOMObserver'
 export { createDOMObserver, DOMObserverEvent, DOMObserverEvents } from './DOMObserver'
 export {


### PR DESCRIPTION
## Summary

Renames the three public methods to align with native `MutationObserver` vocabulary. `observe()` mirrors `MutationObserver.observe()`, `observeOnce()` makes the one-shot semantics self-evident, and `disconnect()` mirrors `MutationObserver.disconnect()`. Option types are renamed accordingly.

## Changes

- `src/DOMObserver.ts` — renamed methods, option types, result type, and all internal calls/JSDoc
- `src/index.ts` — updated type exports (`ObserveOptions`, `ObserveOnceOptions`, `ObserveOnceResult`)
- `src/__tests__/DOMObserver.test.ts` — all method calls and type annotations updated
- `dev/src/index.js` — demo updated to new API
- `README.md` — all examples, tables, and prose updated

## ⚠️ Breaking changes

| Old | New |
|---|---|
| `.watch(target, cb, opts)` | `.observe(target, cb, opts)` |
| `.wait(target, opts)` | `.observeOnce(target, opts)` |
| `.clear()` | `.disconnect()` |
| `WatchOptions` | `ObserveOptions` |
| `WaitOptions` | `ObserveOnceOptions` |
| `WaitResult` | `ObserveOnceResult` |

- Migration is mechanical — a find-and-replace handles all call sites.

## Test plan

- [ ] All 96 tests pass
- [ ] TypeScript: `ObserveOptions`, `ObserveOnceOptions`, `ObserveOnceResult` are importable
- [ ] Demo starts without errors (`yarn dev`)
- [ ] Build produces correct `.d.ts` with new method signatures

Closes #56